### PR TITLE
chore: remove plugin react jsx runtime

### DIFF
--- a/packages/eslint-config-react/rules/react.js
+++ b/packages/eslint-config-react/rules/react.js
@@ -5,7 +5,7 @@ const dangleRules = baseStyleRules['no-underscore-dangle'];
 
 module.exports = {
   plugins: [
-    'react', 'plugin:react/jsx-runtime',
+    'react',
   ],
 
   parserOptions: {

--- a/packages/eslint-config-ts-react/rules/react.js
+++ b/packages/eslint-config-ts-react/rules/react.js
@@ -6,7 +6,7 @@ const baseStyleRules = require('@acolorbright/eslint-config-ts/rules/style')
 const dangleRules = baseStyleRules['no-underscore-dangle']
 
 module.exports = {
-  plugins: ['react', 'plugin:react/jsx-runtime'],
+  plugins: ['react'],
 
   parserOptions: {
     ecmaFeatures: {


### PR DESCRIPTION
Seems this should be added through `extends` and not `plugins` - however adding this results in `Error: Cannot find module 'plugin:react/jsx-runtime'`.

After checking the configuration it seems our current configuration should cover everything from the plugin either way, so it should be ok to remove it completely