### PR TITLE
fix: update peer dependency version

### DIFF
--- a/packages/eslint-config-ts-react/package.json
+++ b/packages/eslint-config-ts-react/package.json
@@ -40,7 +40,7 @@
     "eslint-plugin-jsx-a11y": "6.x",
     "eslint-plugin-prettier": "3.x",
     "eslint-plugin-react": "7.x",
-    "eslint-plugin-react-hooks": "1.x",
+    "eslint-plugin-react-hooks": "4.x",
     "eslint-plugin-simple-import-sort": "7.x",
     "prettier": "2.x",
     "typescript": "4.x"


### PR DESCRIPTION
The outdated peer dependency version didn't take `eslint 7` into account, so newer versions of `npm` would throw an error when installing the package

Closes #30 