### PR TITLE
chore: remove version from publish commit message

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -8,7 +8,7 @@
       "ignoreChanges": [
         "*.md"
       ],
-      "message": "chore(release): publish %s"
+      "message": "chore(release): publish"
     }
   }
 }


### PR DESCRIPTION
From the docs:

>If the message contains %s, it will be replaced with the new global version version number prefixed with a "v". If the message contains %v, it will be replaced with the new global version version number without the leading "v". Note that this placeholder interpolation only applies when using the default "fixed" versioning mode, as there is no "global" version to interpolate when versioning independently.

This removes the version from the commit message written by Lerna on publish
