### PR TITLE
Simplify and upgrade Stylelint config

### DIFF
--- a/packages/stylelint-config/LICENSE.md
+++ b/packages/stylelint-config/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020, 2021 A Color Bright GmbH
+Copyright (c) 2020–2022 A Color Bright GmbH
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/stylelint-config/README.md
+++ b/packages/stylelint-config/README.md
@@ -5,14 +5,12 @@ Stylelint config providing ACB's standard linting setup for styles.
 ## Installation
 
 ```bash
-$ npx install-peerdeps -D @acolorbright/stylelint-config && npm install -DE @acolorbright/stylelint-config@latest
+npm install -DE @acolorbright/stylelint-config@latest
 ```
-
-Since `install-peerdeps` doesn't have a flag to pin the exact version of the installed peer dependencies it's advisable to pin the installed versions in `package.json` by hand.
 
 ## Usage
 
-To start using this configuration, simply extend this package in your Stylelint configuration.
+To start using this configuration, extend this package in your Stylelint configuration.
 
 ```js
 {
@@ -27,6 +25,6 @@ For more information on configuring Stylelint, check out the [configuration](htt
 
 ## Property Ordering
 
-Property ordering is performed according to the [SMACSS](http://smacss.com) methodology.
+Property ordering is performed according to the [SMACSS](http://smacss.com) methodology, with empty lines enforced between property groups.
 
-Refer to [here](https://github.com/cahamilton/css-property-sort-order-smacss/blob/master/index.js) for the comprehensive list of property orders.
+Refer to [css-property-sort-order-smacss](https://github.com/cahamilton/css-property-sort-order-smacss/blob/master/index.js) for the comprehensive list of property orders.

--- a/packages/stylelint-config/index.js
+++ b/packages/stylelint-config/index.js
@@ -1,9 +1,12 @@
+const sortOrderSmacss = require('stylelint-config-property-sort-order-smacss/generate');
+
 module.exports = {
+	plugins: ['stylelint-order'],
 	extends: [
 		'stylelint-config-recommended',
-		'@acolorbright/stylelint-config-property-sort-order',
 	],
 	rules: {
+		'order/properties-order': [sortOrderSmacss({ emptyLineBefore: 'always' })],
 		'at-rule-no-unknown': [true, { ignoreAtRules: ['define-mixin', 'mixin'] }],
 		'at-rule-name-space-after': 'always-single-line',
 		'at-rule-no-vendor-prefix': true,

--- a/packages/stylelint-config/package-lock.json
+++ b/packages/stylelint-config/package-lock.json
@@ -6,48 +6,395 @@
 	"packages": {
 		"": {
 			"name": "@acolorbright/stylelint-config",
-			"version": "3.0.0",
+			"version": "3.1.0",
 			"license": "MIT",
 			"dependencies": {
-				"stylelint-config-recommended": "6.0.0"
+				"stylelint-config-property-sort-order-smacss": "9.0.0",
+				"stylelint-config-recommended": "7.0.0",
+				"stylelint-order": "5.0.0"
 			},
 			"devDependencies": {
+				"@acolorbright/eslint-config": "2.1.1",
 				"eslint": "8.0.1",
 				"eslint-plugin-extra-rules": "0.8.1",
 				"eslint-plugin-import": "2.25.2"
 			},
 			"peerDependencies": {
-				"stylelint": "13.x || 14.x"
+				"stylelint": "^14.4.0"
+			}
+		},
+		"node_modules/@acolorbright/eslint-config": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@acolorbright/eslint-config/-/eslint-config-2.1.1.tgz",
+			"integrity": "sha512-72Z9oVKV2kl4tagkqGLg8R4Nt29kv94CazZMPifayveYGJt7o1cibfO3/zdnhMsCdEs4PoAzbkm2KbvmoASuwQ==",
+			"dev": true,
+			"dependencies": {
+				"confusing-browser-globals": "1.0.10"
+			},
+			"engines": {
+				"node": ">= 6.14"
+			},
+			"peerDependencies": {
+				"@babel/core": "7.x",
+				"@babel/eslint-parser": "7.x",
+				"eslint": "7.x || 8.x",
+				"eslint-plugin-extra-rules": "^0.8",
+				"eslint-plugin-import": "^2.22.1"
+			}
+		},
+		"node_modules/@ampproject/remapping": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.1.2.tgz",
+			"integrity": "sha512-hoyByceqwKirw7w3Z7gnIIZC3Wx3J484Y3L/cMpXFbr7d9ZQj2mODrirNzcJa+SM3UlpWXYvKV4RlRpFXlWgXg==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"@jridgewell/trace-mapping": "^0.3.0"
+			},
+			"engines": {
+				"node": ">=6.0.0"
 			}
 		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
-			"integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
+			"version": "7.16.7",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
+			"integrity": "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
 			"peer": true,
 			"dependencies": {
-				"@babel/highlight": "^7.16.0"
+				"@babel/highlight": "^7.16.7"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/compat-data": {
+			"version": "7.17.0",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.17.0.tgz",
+			"integrity": "sha512-392byTlpGWXMv4FbyWw3sAZ/FrW/DrwqLGXpy0mbyNe9Taqv1mg9yON5/o0cnr8XYCkFTZbC1eV+c+LAROgrng==",
+			"dev": true,
+			"peer": true,
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/core": {
+			"version": "7.17.5",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.5.tgz",
+			"integrity": "sha512-/BBMw4EvjmyquN5O+t5eh0+YqB3XXJkYD2cjKpYtWOfFy4lQ4UozNSmxAcWT8r2XtZs0ewG+zrfsqeR15i1ajA==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"@ampproject/remapping": "^2.1.0",
+				"@babel/code-frame": "^7.16.7",
+				"@babel/generator": "^7.17.3",
+				"@babel/helper-compilation-targets": "^7.16.7",
+				"@babel/helper-module-transforms": "^7.16.7",
+				"@babel/helpers": "^7.17.2",
+				"@babel/parser": "^7.17.3",
+				"@babel/template": "^7.16.7",
+				"@babel/traverse": "^7.17.3",
+				"@babel/types": "^7.17.0",
+				"convert-source-map": "^1.7.0",
+				"debug": "^4.1.0",
+				"gensync": "^1.0.0-beta.2",
+				"json5": "^2.1.2",
+				"semver": "^6.3.0"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/babel"
+			}
+		},
+		"node_modules/@babel/core/node_modules/json5": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
+			"integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"minimist": "^1.2.5"
+			},
+			"bin": {
+				"json5": "lib/cli.js"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/@babel/core/node_modules/semver": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+			"dev": true,
+			"peer": true,
+			"bin": {
+				"semver": "bin/semver.js"
+			}
+		},
+		"node_modules/@babel/eslint-parser": {
+			"version": "7.17.0",
+			"resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.17.0.tgz",
+			"integrity": "sha512-PUEJ7ZBXbRkbq3qqM/jZ2nIuakUBqCYc7Qf52Lj7dlZ6zERnqisdHioL0l4wwQZnmskMeasqUNzLBFKs3nylXA==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"eslint-scope": "^5.1.1",
+				"eslint-visitor-keys": "^2.1.0",
+				"semver": "^6.3.0"
+			},
+			"engines": {
+				"node": "^10.13.0 || ^12.13.0 || >=14.0.0"
+			},
+			"peerDependencies": {
+				"@babel/core": ">=7.11.0",
+				"eslint": "^7.5.0 || ^8.0.0"
+			}
+		},
+		"node_modules/@babel/eslint-parser/node_modules/eslint-scope": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+			"integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"esrecurse": "^4.3.0",
+				"estraverse": "^4.1.1"
+			},
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/@babel/eslint-parser/node_modules/eslint-visitor-keys": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+			"integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+			"dev": true,
+			"peer": true,
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@babel/eslint-parser/node_modules/estraverse": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+			"dev": true,
+			"peer": true,
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
+		"node_modules/@babel/eslint-parser/node_modules/semver": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+			"dev": true,
+			"peer": true,
+			"bin": {
+				"semver": "bin/semver.js"
+			}
+		},
+		"node_modules/@babel/generator": {
+			"version": "7.17.3",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.3.tgz",
+			"integrity": "sha512-+R6Dctil/MgUsZsZAkYgK+ADNSZzJRRy0TvY65T71z/CR854xHQ1EweBYXdfT+HNeN7w0cSJJEzgxZMv40pxsg==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"@babel/types": "^7.17.0",
+				"jsesc": "^2.5.1",
+				"source-map": "^0.5.0"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-compilation-targets": {
+			"version": "7.16.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.16.7.tgz",
+			"integrity": "sha512-mGojBwIWcwGD6rfqgRXVlVYmPAv7eOpIemUG3dGnDdCY4Pae70ROij3XmfrH6Fa1h1aiDylpglbZyktfzyo/hA==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"@babel/compat-data": "^7.16.4",
+				"@babel/helper-validator-option": "^7.16.7",
+				"browserslist": "^4.17.5",
+				"semver": "^6.3.0"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0"
+			}
+		},
+		"node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+			"dev": true,
+			"peer": true,
+			"bin": {
+				"semver": "bin/semver.js"
+			}
+		},
+		"node_modules/@babel/helper-environment-visitor": {
+			"version": "7.16.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.16.7.tgz",
+			"integrity": "sha512-SLLb0AAn6PkUeAfKJCCOl9e1R53pQlGAfc4y4XuMRZfqeMYLE0dM1LMhqbGAlGQY0lfw5/ohoYWAe9V1yibRag==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"@babel/types": "^7.16.7"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-function-name": {
+			"version": "7.16.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.7.tgz",
+			"integrity": "sha512-QfDfEnIUyyBSR3HtrtGECuZ6DAyCkYFp7GHl75vFtTnn6pjKeK0T1DB5lLkFvBea8MdaiUABx3osbgLyInoejA==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"@babel/helper-get-function-arity": "^7.16.7",
+				"@babel/template": "^7.16.7",
+				"@babel/types": "^7.16.7"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-get-function-arity": {
+			"version": "7.16.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.7.tgz",
+			"integrity": "sha512-flc+RLSOBXzNzVhcLu6ujeHUrD6tANAOU5ojrRx/as+tbzf8+stUCj7+IfRRoAbEZqj/ahXEMsjhOhgeZsrnTw==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"@babel/types": "^7.16.7"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-hoist-variables": {
+			"version": "7.16.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.7.tgz",
+			"integrity": "sha512-m04d/0Op34H5v7pbZw6pSKP7weA6lsMvfiIAMeIvkY/R4xQtBSMFEigu9QTZ2qB/9l22vsxtM8a+Q8CzD255fg==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"@babel/types": "^7.16.7"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-module-imports": {
+			"version": "7.16.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.16.7.tgz",
+			"integrity": "sha512-LVtS6TqjJHFc+nYeITRo6VLXve70xmq7wPhWTqDJusJEgGmkAACWwMiTNrvfoQo6hEhFwAIixNkvB0jPXDL8Wg==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"@babel/types": "^7.16.7"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-module-transforms": {
+			"version": "7.16.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.16.7.tgz",
+			"integrity": "sha512-gaqtLDxJEFCeQbYp9aLAefjhkKdjKcdh6DB7jniIGU3Pz52WAmP268zK0VgPz9hUNkMSYeH976K2/Y6yPadpng==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"@babel/helper-environment-visitor": "^7.16.7",
+				"@babel/helper-module-imports": "^7.16.7",
+				"@babel/helper-simple-access": "^7.16.7",
+				"@babel/helper-split-export-declaration": "^7.16.7",
+				"@babel/helper-validator-identifier": "^7.16.7",
+				"@babel/template": "^7.16.7",
+				"@babel/traverse": "^7.16.7",
+				"@babel/types": "^7.16.7"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-simple-access": {
+			"version": "7.16.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.16.7.tgz",
+			"integrity": "sha512-ZIzHVyoeLMvXMN/vok/a4LWRy8G2v205mNP0XOuf9XRLyX5/u9CnVulUtDgUTama3lT+bf/UqucuZjqiGuTS1g==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"@babel/types": "^7.16.7"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-split-export-declaration": {
+			"version": "7.16.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.7.tgz",
+			"integrity": "sha512-xbWoy/PFoxSWazIToT9Sif+jJTlrMcndIsaOKvTA6u7QEo7ilkRZpjew18/W3c7nm8fXdUDXh02VXTbZ0pGDNw==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"@babel/types": "^7.16.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.15.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
-			"integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
+			"version": "7.16.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
+			"integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
 			"peer": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
-		"node_modules/@babel/highlight": {
-			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.0.tgz",
-			"integrity": "sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==",
+		"node_modules/@babel/helper-validator-option": {
+			"version": "7.16.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.16.7.tgz",
+			"integrity": "sha512-TRtenOuRUVo9oIQGPC5G9DgK4743cdxvtOw0weQNpZXaS16SCBi5MNjZF8vba3ETURjZpTbVn7Vvcf2eAwFozQ==",
+			"dev": true,
+			"peer": true,
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helpers": {
+			"version": "7.17.2",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.17.2.tgz",
+			"integrity": "sha512-0Qu7RLR1dILozr/6M0xgj+DFPmi6Bnulgm9M8BVa9ZCWxDqlSnqt3cf8IDPB5m45sVXUZ0kuQAgUrdSFFH79fQ==",
+			"dev": true,
 			"peer": true,
 			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.15.7",
+				"@babel/template": "^7.16.7",
+				"@babel/traverse": "^7.17.0",
+				"@babel/types": "^7.17.0"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/highlight": {
+			"version": "7.16.10",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.10.tgz",
+			"integrity": "sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==",
+			"peer": true,
+			"dependencies": {
+				"@babel/helper-validator-identifier": "^7.16.7",
 				"chalk": "^2.0.0",
 				"js-tokens": "^4.0.0"
 			},
@@ -126,6 +473,80 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/@babel/parser": {
+			"version": "7.17.3",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.3.tgz",
+			"integrity": "sha512-7yJPvPV+ESz2IUTPbOL+YkIGyCqOyNIzdguKQuJGnH7bg1WTIifuM21YqokFt/THWh1AkCRn9IgoykTRCBVpzA==",
+			"dev": true,
+			"peer": true,
+			"bin": {
+				"parser": "bin/babel-parser.js"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@babel/template": {
+			"version": "7.16.7",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.7.tgz",
+			"integrity": "sha512-I8j/x8kHUrbYRTUxXrrMbfCa7jxkE7tZre39x3kjr9hvI82cK1FfqLygotcWN5kdPGWcLdWMHpSBavse5tWw3w==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"@babel/code-frame": "^7.16.7",
+				"@babel/parser": "^7.16.7",
+				"@babel/types": "^7.16.7"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/traverse": {
+			"version": "7.17.3",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.3.tgz",
+			"integrity": "sha512-5irClVky7TxRWIRtxlh2WPUUOLhcPN06AGgaQSB8AEwuyEBgJVuJ5imdHm5zxk8w0QS5T+tDfnDxAlhWjpb7cw==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"@babel/code-frame": "^7.16.7",
+				"@babel/generator": "^7.17.3",
+				"@babel/helper-environment-visitor": "^7.16.7",
+				"@babel/helper-function-name": "^7.16.7",
+				"@babel/helper-hoist-variables": "^7.16.7",
+				"@babel/helper-split-export-declaration": "^7.16.7",
+				"@babel/parser": "^7.17.3",
+				"@babel/types": "^7.17.0",
+				"debug": "^4.1.0",
+				"globals": "^11.1.0"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/traverse/node_modules/globals": {
+			"version": "11.12.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+			"dev": true,
+			"peer": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/@babel/types": {
+			"version": "7.17.0",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
+			"integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"@babel/helper-validator-identifier": "^7.16.7",
+				"to-fast-properties": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
 		"node_modules/@eslint/eslintrc": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.0.3.tgz",
@@ -178,6 +599,34 @@
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz",
 			"integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==",
 			"dev": true
+		},
+		"node_modules/@jridgewell/resolve-uri": {
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.5.tgz",
+			"integrity": "sha512-VPeQ7+wH0itvQxnG+lIzWgkysKIr3L9sslimFW55rHMdGu/qCQ5z5h9zq4gI8uBtqkpHhsF4Z/OwExufUCThew==",
+			"dev": true,
+			"peer": true,
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@jridgewell/sourcemap-codec": {
+			"version": "1.4.11",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.11.tgz",
+			"integrity": "sha512-Fg32GrJo61m+VqYSdRSjRXMjQ06j8YIYfcTqndLYVAaHmroZHLJZCydsWBOTDqXS2v+mjxohBWEMfg97GXmYQg==",
+			"dev": true,
+			"peer": true
+		},
+		"node_modules/@jridgewell/trace-mapping": {
+			"version": "0.3.4",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.4.tgz",
+			"integrity": "sha512-vFv9ttIedivx0ux3QSjhgtCVjPZd5l46ZOMDSCwnH1yUO2e964gO8LZGyv2QkqcgR6TnBU1v+1IFqmeoG+0UJQ==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"@jridgewell/resolve-uri": "^3.0.3",
+				"@jridgewell/sourcemap-codec": "^1.4.10"
+			}
 		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
@@ -404,6 +853,30 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/browserslist": {
+			"version": "4.19.3",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.19.3.tgz",
+			"integrity": "sha512-XK3X4xtKJ+Txj8G5c30B4gsm71s69lqXlkYui4s6EkKxuv49qjYlY6oVd+IFJ73d4YymtM3+djvvt/R/iJwwDg==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"caniuse-lite": "^1.0.30001312",
+				"electron-to-chromium": "^1.4.71",
+				"escalade": "^3.1.1",
+				"node-releases": "^2.0.2",
+				"picocolors": "^1.0.0"
+			},
+			"bin": {
+				"browserslist": "cli.js"
+			},
+			"engines": {
+				"node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/browserslist"
+			}
+		},
 		"node_modules/call-bind": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
@@ -451,6 +924,17 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/caniuse-lite": {
+			"version": "1.0.30001312",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001312.tgz",
+			"integrity": "sha512-Wiz1Psk2MEK0pX3rUzWaunLTZzqS2JYZFzNKqAiJGiuxIjRPLgV6+VDPOg6lQOUxmDwhTlh198JsTTi8Hzw6aQ==",
+			"dev": true,
+			"peer": true,
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/browserslist"
+			}
+		},
 		"node_modules/chalk": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -495,16 +979,38 @@
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
 		},
+		"node_modules/colord": {
+			"version": "2.9.2",
+			"resolved": "https://registry.npmjs.org/colord/-/colord-2.9.2.tgz",
+			"integrity": "sha512-Uqbg+J445nc1TKn4FoDPS6ZZqAvEDnwrH42yo8B40JSOgSLxMZ/gt3h4nmCtPLQeXhjJJkqBx7SCY35WnIixaQ==",
+			"peer": true
+		},
 		"node_modules/concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+		},
+		"node_modules/confusing-browser-globals": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.10.tgz",
+			"integrity": "sha512-gNld/3lySHwuhaVluJUKLePYirM3QNCKzVxqAdhJII9/WXKVX5PURzMVJspS1jTslSqjeuG4KMVTSouit5YPHA==",
+			"dev": true
 		},
 		"node_modules/console-assert": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/console-assert/-/console-assert-1.0.0.tgz",
 			"integrity": "sha1-cBZwKO8I7BZnoMaHIFqDYOsRc2c=",
 			"dev": true
+		},
+		"node_modules/convert-source-map": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
+			"integrity": "sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"safe-buffer": "~5.1.1"
+			}
 		},
 		"node_modules/cosmiconfig": {
 			"version": "7.0.1",
@@ -536,6 +1042,20 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/css-functions-list": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.0.1.tgz",
+			"integrity": "sha512-PriDuifDt4u4rkDgnqRCLnjfMatufLmWNfQnGCq34xZwpY3oabwhB9SqRBmuvWUgndbemCFlKqg+nO7C2q0SBw==",
+			"peer": true,
+			"engines": {
+				"node": ">=12.22"
+			}
+		},
+		"node_modules/css-property-sort-order-smacss": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/css-property-sort-order-smacss/-/css-property-sort-order-smacss-2.2.0.tgz",
+			"integrity": "sha512-nXutswsivIEBOrPo/OZw2KQjFPLvtg68aovJf6Kqrm3L6FmTvvFPaeDrk83hh0+pRJGuP3PeKJwMS0E6DFipdQ=="
+		},
 		"node_modules/cssesc": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -549,9 +1069,9 @@
 			}
 		},
 		"node_modules/debug": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-			"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+			"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
 			"dependencies": {
 				"ms": "2.1.2"
 			},
@@ -637,6 +1157,13 @@
 				"node": ">=6.0.0"
 			}
 		},
+		"node_modules/electron-to-chromium": {
+			"version": "1.4.71",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.71.tgz",
+			"integrity": "sha512-Hk61vXXKRb2cd3znPE9F+2pLWdIOmP7GjiTj45y6L3W/lO+hSnUSUhq+6lEaERWBdZOHbk2s3YV5c9xVl3boVw==",
+			"dev": true,
+			"peer": true
+		},
 		"node_modules/emoji-regex": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -713,6 +1240,16 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/escalade": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+			"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+			"dev": true,
+			"peer": true,
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/escape-string-regexp": {
@@ -1066,9 +1603,9 @@
 			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
 		},
 		"node_modules/fast-glob": {
-			"version": "3.2.7",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
-			"integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
+			"version": "3.2.11",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+			"integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
 			"peer": true,
 			"dependencies": {
 				"@nodelib/fs.stat": "^2.0.2",
@@ -1078,7 +1615,7 @@
 				"micromatch": "^4.0.4"
 			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=8.6.0"
 			}
 		},
 		"node_modules/fast-glob/node_modules/glob-parent": {
@@ -1187,6 +1724,16 @@
 			"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
 			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
 			"dev": true
+		},
+		"node_modules/gensync": {
+			"version": "1.0.0-beta.2",
+			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+			"integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+			"dev": true,
+			"peer": true,
+			"engines": {
+				"node": ">=6.9.0"
+			}
 		},
 		"node_modules/get-intrinsic": {
 			"version": "1.1.1",
@@ -1315,16 +1862,16 @@
 			}
 		},
 		"node_modules/globby": {
-			"version": "11.0.4",
-			"resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
-			"integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
+			"version": "11.1.0",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+			"integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
 			"peer": true,
 			"dependencies": {
 				"array-union": "^2.1.0",
 				"dir-glob": "^3.0.1",
-				"fast-glob": "^3.1.1",
-				"ignore": "^5.1.4",
-				"merge2": "^1.3.0",
+				"fast-glob": "^3.2.9",
+				"ignore": "^5.2.0",
+				"merge2": "^1.4.1",
 				"slash": "^3.0.0"
 			},
 			"engines": {
@@ -1335,9 +1882,9 @@
 			}
 		},
 		"node_modules/globby/node_modules/ignore": {
-			"version": "5.1.9",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.9.tgz",
-			"integrity": "sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+			"integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
 			"peer": true,
 			"engines": {
 				"node": ">= 4"
@@ -1382,7 +1929,6 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-			"dev": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -1737,12 +2283,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/is-typedarray": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-			"peer": true
-		},
 		"node_modules/is-weakref": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.1.tgz",
@@ -1784,6 +2324,19 @@
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
 			"dev": true
 		},
+		"node_modules/jsesc": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+			"dev": true,
+			"peer": true,
+			"bin": {
+				"jsesc": "bin/jsesc"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/json-parse-even-better-errors": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -1824,9 +2377,9 @@
 			}
 		},
 		"node_modules/known-css-properties": {
-			"version": "0.23.0",
-			"resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.23.0.tgz",
-			"integrity": "sha512-h9ivI88e1lFNmTT4HovBN33Ysn0OIJG7IPG2mkpx2uniQXFWqo35QdiX7w0TovlUFXfW8aPFblP5/q0jlOr2sA==",
+			"version": "0.24.0",
+			"resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.24.0.tgz",
+			"integrity": "sha512-RTSoaUAfLvpR357vWzAz/50Q/BmHfmE6ETSWfutT0AJiw10e6CmcdYRQJlLRd95B53D0Y2aD1jSxD3V3ySF+PA==",
 			"peer": true
 		},
 		"node_modules/levn": {
@@ -2012,10 +2565,9 @@
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 		},
 		"node_modules/nanoid": {
-			"version": "3.1.30",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.30.tgz",
-			"integrity": "sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ==",
-			"peer": true,
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
+			"integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
 			"bin": {
 				"nanoid": "bin/nanoid.cjs"
 			},
@@ -2028,6 +2580,13 @@
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
 			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
 			"dev": true
+		},
+		"node_modules/node-releases": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.2.tgz",
+			"integrity": "sha512-XxYDdcQ6eKqp/YjI+tb2C5WM2LgjnZrfYg4vgQt49EK268b6gYCHsBLrK2qvJo4FmCtqmKezb0WZFK4fkrZNsg==",
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/normalize-package-data": {
 			"version": "3.0.3",
@@ -2242,13 +2801,12 @@
 		"node_modules/picocolors": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-			"integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-			"peer": true
+			"integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
 		},
 		"node_modules/picomatch": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-			"integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
 			"peer": true,
 			"engines": {
 				"node": ">=8.6"
@@ -2270,14 +2828,13 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.3.11",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.11.tgz",
-			"integrity": "sha512-hCmlUAIlUiav8Xdqw3Io4LcpA1DOt7h3LSTAC4G6JGHFFaWzI6qvFt9oilvl8BmkbBRX1IhM90ZAmpk68zccQA==",
-			"peer": true,
+			"version": "8.4.6",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.6.tgz",
+			"integrity": "sha512-OovjwIzs9Te46vlEx7+uXB0PLijpwjXGKXjVGGPIGubGpq7uh5Xgf6D6FiJ/SzJMBosHDp6a2hiXOS97iBXcaA==",
 			"dependencies": {
-				"nanoid": "^3.1.30",
+				"nanoid": "^3.2.0",
 				"picocolors": "^1.0.0",
-				"source-map-js": "^0.6.2"
+				"source-map-js": "^1.0.2"
 			},
 			"engines": {
 				"node": "^10 || ^12 || >=14"
@@ -2316,9 +2873,9 @@
 			}
 		},
 		"node_modules/postcss-selector-parser": {
-			"version": "6.0.6",
-			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.6.tgz",
-			"integrity": "sha512-9LXrvaaX3+mcv5xkg5kFwqSzSH1JIObIx51PrndZwlmznwXRfxMddDvo9gve3gVR8ZTKgoFDdWkbRFmEhT4PMg==",
+			"version": "6.0.9",
+			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.9.tgz",
+			"integrity": "sha512-UO3SgnZOVTwu4kyLR22UQ1xZh086RyNZppb7lLAKBFK8a32ttG5i87Y/P3+2bRSjZNyJ1B7hfFNo273tKe9YxQ==",
 			"peer": true,
 			"dependencies": {
 				"cssesc": "^3.0.0",
@@ -2328,10 +2885,18 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/postcss-sorting": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-sorting/-/postcss-sorting-7.0.1.tgz",
+			"integrity": "sha512-iLBFYz6VRYyLJEJsBJ8M3TCqNcckVzz4wFounSc5Oez35ogE/X+aoC5fFu103Ot7NyvjU3/xqIXn93Gp3kJk4g==",
+			"peerDependencies": {
+				"postcss": "^8.3.9"
+			}
+		},
 		"node_modules/postcss-value-parser": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
-			"integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+			"integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
 			"peer": true
 		},
 		"node_modules/prelude-ls": {
@@ -2643,6 +3208,13 @@
 				"queue-microtask": "^1.2.2"
 			}
 		},
+		"node_modules/safe-buffer": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+			"dev": true,
+			"peer": true
+		},
 		"node_modules/semver": {
 			"version": "7.3.5",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
@@ -2693,9 +3265,9 @@
 			}
 		},
 		"node_modules/signal-exit": {
-			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.5.tgz",
-			"integrity": "sha512-KWcOiKeQj6ZyXx7zq4YxSMgHRlod4czeBQZrPb8OKcohcqAXShm7E20kEMle9WBt26hFcAf0qLOcp5zmY7kOqQ==",
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
 			"peer": true
 		},
 		"node_modules/slash": {
@@ -2724,11 +3296,20 @@
 				"url": "https://github.com/chalk/slice-ansi?sponsor=1"
 			}
 		},
-		"node_modules/source-map-js": {
-			"version": "0.6.2",
-			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-0.6.2.tgz",
-			"integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==",
+		"node_modules/source-map": {
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+			"dev": true,
 			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/source-map-js": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+			"integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -2871,49 +3452,52 @@
 			"peer": true
 		},
 		"node_modules/stylelint": {
-			"version": "14.0.1",
-			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.0.1.tgz",
-			"integrity": "sha512-ZcAkmFLVCultmwkQUjxKzxW/o5+CzNmDk6TPJj/d4Y7ipTGGrewIWmNm+InjdSr04PR5/yynsAJeYJY/wisdMg==",
+			"version": "14.5.1",
+			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.5.1.tgz",
+			"integrity": "sha512-8Hf4HtnhxlWlf7iXF9zFfhSc3X0teRnVzl6PqPs2JEFx+dy/mhMhghZfiTDW4QG0ihDw9+WP7GZw5Nzx7cQF5A==",
 			"peer": true,
 			"dependencies": {
 				"balanced-match": "^2.0.0",
+				"colord": "^2.9.2",
 				"cosmiconfig": "^7.0.1",
-				"debug": "^4.3.2",
+				"css-functions-list": "^3.0.1",
+				"debug": "^4.3.3",
 				"execall": "^2.0.0",
-				"fast-glob": "^3.2.7",
+				"fast-glob": "^3.2.11",
 				"fastest-levenshtein": "^1.0.12",
 				"file-entry-cache": "^6.0.1",
 				"get-stdin": "^8.0.0",
 				"global-modules": "^2.0.0",
-				"globby": "^11.0.4",
+				"globby": "^11.1.0",
 				"globjoin": "^0.1.4",
 				"html-tags": "^3.1.0",
-				"ignore": "^5.1.8",
+				"ignore": "^5.2.0",
 				"import-lazy": "^4.0.0",
 				"imurmurhash": "^0.1.4",
 				"is-plain-object": "^5.0.0",
-				"known-css-properties": "^0.23.0",
+				"known-css-properties": "^0.24.0",
 				"mathml-tag-names": "^2.1.3",
 				"meow": "^9.0.0",
 				"micromatch": "^4.0.4",
 				"normalize-path": "^3.0.0",
 				"normalize-selector": "^0.2.0",
 				"picocolors": "^1.0.0",
-				"postcss": "^8.3.11",
+				"postcss": "^8.4.6",
 				"postcss-media-query-parser": "^0.2.3",
 				"postcss-resolve-nested-selector": "^0.1.1",
 				"postcss-safe-parser": "^6.0.0",
-				"postcss-selector-parser": "^6.0.6",
-				"postcss-value-parser": "^4.1.0",
+				"postcss-selector-parser": "^6.0.9",
+				"postcss-value-parser": "^4.2.0",
 				"resolve-from": "^5.0.0",
 				"specificity": "^0.4.1",
 				"string-width": "^4.2.3",
 				"strip-ansi": "^6.0.1",
 				"style-search": "^0.1.0",
+				"supports-hyperlinks": "^2.2.0",
 				"svg-tags": "^1.0.0",
-				"table": "^6.7.2",
+				"table": "^6.8.0",
 				"v8-compile-cache": "^2.3.0",
-				"write-file-atomic": "^3.0.3"
+				"write-file-atomic": "^4.0.1"
 			},
 			"bin": {
 				"stylelint": "bin/stylelint.js"
@@ -2926,10 +3510,34 @@
 				"url": "https://opencollective.com/stylelint"
 			}
 		},
+		"node_modules/stylelint-config-property-sort-order-smacss": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/stylelint-config-property-sort-order-smacss/-/stylelint-config-property-sort-order-smacss-9.0.0.tgz",
+			"integrity": "sha512-jQ1miJ6uQA+n6UkunhdhBmjFd5XCe/X7l9/yBI2KGdU+8+nYt1/7slHeLvsT7SCYByYqaLt9fUUCCOjyXH6PCw==",
+			"dependencies": {
+				"css-property-sort-order-smacss": "~2.2.0",
+				"stylelint-order": "^5.0.0"
+			},
+			"peerDependencies": {
+				"stylelint": "^14.0.0"
+			}
+		},
 		"node_modules/stylelint-config-recommended": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-6.0.0.tgz",
-			"integrity": "sha512-ZorSSdyMcxWpROYUvLEMm0vSZud2uB7tX1hzBZwvVY9SV/uly4AvvJPPhCcymZL3fcQhEQG5AELmrxWqtmzacw==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-7.0.0.tgz",
+			"integrity": "sha512-yGn84Bf/q41J4luis1AZ95gj0EQwRX8lWmGmBwkwBNSkpGSpl66XcPTulxGa/Z91aPoNGuIGBmFkcM1MejMo9Q==",
+			"peerDependencies": {
+				"stylelint": "^14.4.0"
+			}
+		},
+		"node_modules/stylelint-order": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/stylelint-order/-/stylelint-order-5.0.0.tgz",
+			"integrity": "sha512-OWQ7pmicXufDw5BlRqzdz3fkGKJPgLyDwD1rFY3AIEfIH/LQY38Vu/85v8/up0I+VPiuGRwbc2Hg3zLAsJaiyw==",
+			"dependencies": {
+				"postcss": "^8.3.11",
+				"postcss-sorting": "^7.0.1"
+			},
 			"peerDependencies": {
 				"stylelint": "^14.0.0"
 			}
@@ -2941,9 +3549,9 @@
 			"peer": true
 		},
 		"node_modules/stylelint/node_modules/ignore": {
-			"version": "5.1.9",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.9.tgz",
-			"integrity": "sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+			"integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
 			"peer": true,
 			"engines": {
 				"node": ">= 4"
@@ -2962,9 +3570,21 @@
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
 			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-			"dev": true,
 			"dependencies": {
 				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/supports-hyperlinks": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.2.0.tgz",
+			"integrity": "sha512-6sXEzV5+I5j8Bmq9/vUphGRM/RJNT9SCURJLjwfOg51heRtguGWDzcaBlgAzKhQa0EVNpPEKzQuBwZ8S8WaCeQ==",
+			"peer": true,
+			"dependencies": {
+				"has-flag": "^4.0.0",
+				"supports-color": "^7.0.0"
 			},
 			"engines": {
 				"node": ">=8"
@@ -2977,9 +3597,9 @@
 			"peer": true
 		},
 		"node_modules/table": {
-			"version": "6.7.3",
-			"resolved": "https://registry.npmjs.org/table/-/table-6.7.3.tgz",
-			"integrity": "sha512-5DkIxeA7XERBqMwJq0aHZOdMadBx4e6eDoFRuyT5VR82J0Ycg2DwM6GfA/EQAhJ+toRTaS1lIdSQCqgrmhPnlw==",
+			"version": "6.8.0",
+			"resolved": "https://registry.npmjs.org/table/-/table-6.8.0.tgz",
+			"integrity": "sha512-s/fitrbVeEyHKFa7mFdkuQMWlH1Wgw/yEXMt5xACT4ZpzWFluehAxRtUUQKPuWhaLAWhFcVx6w3oC8VKaUfPGA==",
 			"peer": true,
 			"dependencies": {
 				"ajv": "^8.0.1",
@@ -2993,9 +3613,9 @@
 			}
 		},
 		"node_modules/table/node_modules/ajv": {
-			"version": "8.7.1",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.7.1.tgz",
-			"integrity": "sha512-gPpOObTO1QjbnN1sVMjJcp1TF9nggMfO4MBR5uQl6ZVTOaEPq5i4oq/6R9q2alMMPB3eg53wFv1RuJBLuxf3Hw==",
+			"version": "8.10.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.10.0.tgz",
+			"integrity": "sha512-bzqAEZOjkrUMl2afH8dknrq5KEk2SrwdBROR+vH1EKVQTqaUbJVPdc/gEdggTMM0Se+s+Ja4ju4TlNcStKl2Hw==",
 			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
@@ -3019,6 +3639,16 @@
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
 			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
 			"dev": true
+		},
+		"node_modules/to-fast-properties": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+			"dev": true,
+			"peer": true,
+			"engines": {
+				"node": ">=4"
+			}
 		},
 		"node_modules/to-regex-range": {
 			"version": "5.0.1",
@@ -3075,15 +3705,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/typedarray-to-buffer": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
-			"integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-			"peer": true,
-			"dependencies": {
-				"is-typedarray": "^1.0.0"
 			}
 		},
 		"node_modules/unbox-primitive": {
@@ -3176,15 +3797,16 @@
 			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		},
 		"node_modules/write-file-atomic": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
-			"integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.1.tgz",
+			"integrity": "sha512-nSKUxgAbyioruk6hU87QzVbY279oYT6uiwgDoujth2ju4mJ+TZau7SQBhtbTmUyuNYTuXnSyRn66FV0+eCgcrQ==",
 			"peer": true,
 			"dependencies": {
 				"imurmurhash": "^0.1.4",
-				"is-typedarray": "^1.0.0",
-				"signal-exit": "^3.0.2",
-				"typedarray-to-buffer": "^3.1.5"
+				"signal-exit": "^3.0.7"
+			},
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || >=16"
 			}
 		},
 		"node_modules/yallist": {
@@ -3212,28 +3834,285 @@
 		}
 	},
 	"dependencies": {
-		"@babel/code-frame": {
-			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
-			"integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
+		"@acolorbright/eslint-config": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@acolorbright/eslint-config/-/eslint-config-2.1.1.tgz",
+			"integrity": "sha512-72Z9oVKV2kl4tagkqGLg8R4Nt29kv94CazZMPifayveYGJt7o1cibfO3/zdnhMsCdEs4PoAzbkm2KbvmoASuwQ==",
+			"dev": true,
+			"requires": {
+				"confusing-browser-globals": "1.0.10"
+			}
+		},
+		"@ampproject/remapping": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.1.2.tgz",
+			"integrity": "sha512-hoyByceqwKirw7w3Z7gnIIZC3Wx3J484Y3L/cMpXFbr7d9ZQj2mODrirNzcJa+SM3UlpWXYvKV4RlRpFXlWgXg==",
+			"dev": true,
 			"peer": true,
 			"requires": {
-				"@babel/highlight": "^7.16.0"
+				"@jridgewell/trace-mapping": "^0.3.0"
+			}
+		},
+		"@babel/code-frame": {
+			"version": "7.16.7",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
+			"integrity": "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
+			"peer": true,
+			"requires": {
+				"@babel/highlight": "^7.16.7"
+			}
+		},
+		"@babel/compat-data": {
+			"version": "7.17.0",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.17.0.tgz",
+			"integrity": "sha512-392byTlpGWXMv4FbyWw3sAZ/FrW/DrwqLGXpy0mbyNe9Taqv1mg9yON5/o0cnr8XYCkFTZbC1eV+c+LAROgrng==",
+			"dev": true,
+			"peer": true
+		},
+		"@babel/core": {
+			"version": "7.17.5",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.5.tgz",
+			"integrity": "sha512-/BBMw4EvjmyquN5O+t5eh0+YqB3XXJkYD2cjKpYtWOfFy4lQ4UozNSmxAcWT8r2XtZs0ewG+zrfsqeR15i1ajA==",
+			"dev": true,
+			"peer": true,
+			"requires": {
+				"@ampproject/remapping": "^2.1.0",
+				"@babel/code-frame": "^7.16.7",
+				"@babel/generator": "^7.17.3",
+				"@babel/helper-compilation-targets": "^7.16.7",
+				"@babel/helper-module-transforms": "^7.16.7",
+				"@babel/helpers": "^7.17.2",
+				"@babel/parser": "^7.17.3",
+				"@babel/template": "^7.16.7",
+				"@babel/traverse": "^7.17.3",
+				"@babel/types": "^7.17.0",
+				"convert-source-map": "^1.7.0",
+				"debug": "^4.1.0",
+				"gensync": "^1.0.0-beta.2",
+				"json5": "^2.1.2",
+				"semver": "^6.3.0"
+			},
+			"dependencies": {
+				"json5": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
+					"integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+					"dev": true,
+					"peer": true,
+					"requires": {
+						"minimist": "^1.2.5"
+					}
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true,
+					"peer": true
+				}
+			}
+		},
+		"@babel/eslint-parser": {
+			"version": "7.17.0",
+			"resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.17.0.tgz",
+			"integrity": "sha512-PUEJ7ZBXbRkbq3qqM/jZ2nIuakUBqCYc7Qf52Lj7dlZ6zERnqisdHioL0l4wwQZnmskMeasqUNzLBFKs3nylXA==",
+			"dev": true,
+			"peer": true,
+			"requires": {
+				"eslint-scope": "^5.1.1",
+				"eslint-visitor-keys": "^2.1.0",
+				"semver": "^6.3.0"
+			},
+			"dependencies": {
+				"eslint-scope": {
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+					"integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+					"dev": true,
+					"peer": true,
+					"requires": {
+						"esrecurse": "^4.3.0",
+						"estraverse": "^4.1.1"
+					}
+				},
+				"eslint-visitor-keys": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+					"integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+					"dev": true,
+					"peer": true
+				},
+				"estraverse": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+					"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+					"dev": true,
+					"peer": true
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true,
+					"peer": true
+				}
+			}
+		},
+		"@babel/generator": {
+			"version": "7.17.3",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.3.tgz",
+			"integrity": "sha512-+R6Dctil/MgUsZsZAkYgK+ADNSZzJRRy0TvY65T71z/CR854xHQ1EweBYXdfT+HNeN7w0cSJJEzgxZMv40pxsg==",
+			"dev": true,
+			"peer": true,
+			"requires": {
+				"@babel/types": "^7.17.0",
+				"jsesc": "^2.5.1",
+				"source-map": "^0.5.0"
+			}
+		},
+		"@babel/helper-compilation-targets": {
+			"version": "7.16.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.16.7.tgz",
+			"integrity": "sha512-mGojBwIWcwGD6rfqgRXVlVYmPAv7eOpIemUG3dGnDdCY4Pae70ROij3XmfrH6Fa1h1aiDylpglbZyktfzyo/hA==",
+			"dev": true,
+			"peer": true,
+			"requires": {
+				"@babel/compat-data": "^7.16.4",
+				"@babel/helper-validator-option": "^7.16.7",
+				"browserslist": "^4.17.5",
+				"semver": "^6.3.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true,
+					"peer": true
+				}
+			}
+		},
+		"@babel/helper-environment-visitor": {
+			"version": "7.16.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.16.7.tgz",
+			"integrity": "sha512-SLLb0AAn6PkUeAfKJCCOl9e1R53pQlGAfc4y4XuMRZfqeMYLE0dM1LMhqbGAlGQY0lfw5/ohoYWAe9V1yibRag==",
+			"dev": true,
+			"peer": true,
+			"requires": {
+				"@babel/types": "^7.16.7"
+			}
+		},
+		"@babel/helper-function-name": {
+			"version": "7.16.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.7.tgz",
+			"integrity": "sha512-QfDfEnIUyyBSR3HtrtGECuZ6DAyCkYFp7GHl75vFtTnn6pjKeK0T1DB5lLkFvBea8MdaiUABx3osbgLyInoejA==",
+			"dev": true,
+			"peer": true,
+			"requires": {
+				"@babel/helper-get-function-arity": "^7.16.7",
+				"@babel/template": "^7.16.7",
+				"@babel/types": "^7.16.7"
+			}
+		},
+		"@babel/helper-get-function-arity": {
+			"version": "7.16.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.7.tgz",
+			"integrity": "sha512-flc+RLSOBXzNzVhcLu6ujeHUrD6tANAOU5ojrRx/as+tbzf8+stUCj7+IfRRoAbEZqj/ahXEMsjhOhgeZsrnTw==",
+			"dev": true,
+			"peer": true,
+			"requires": {
+				"@babel/types": "^7.16.7"
+			}
+		},
+		"@babel/helper-hoist-variables": {
+			"version": "7.16.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.7.tgz",
+			"integrity": "sha512-m04d/0Op34H5v7pbZw6pSKP7weA6lsMvfiIAMeIvkY/R4xQtBSMFEigu9QTZ2qB/9l22vsxtM8a+Q8CzD255fg==",
+			"dev": true,
+			"peer": true,
+			"requires": {
+				"@babel/types": "^7.16.7"
+			}
+		},
+		"@babel/helper-module-imports": {
+			"version": "7.16.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.16.7.tgz",
+			"integrity": "sha512-LVtS6TqjJHFc+nYeITRo6VLXve70xmq7wPhWTqDJusJEgGmkAACWwMiTNrvfoQo6hEhFwAIixNkvB0jPXDL8Wg==",
+			"dev": true,
+			"peer": true,
+			"requires": {
+				"@babel/types": "^7.16.7"
+			}
+		},
+		"@babel/helper-module-transforms": {
+			"version": "7.16.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.16.7.tgz",
+			"integrity": "sha512-gaqtLDxJEFCeQbYp9aLAefjhkKdjKcdh6DB7jniIGU3Pz52WAmP268zK0VgPz9hUNkMSYeH976K2/Y6yPadpng==",
+			"dev": true,
+			"peer": true,
+			"requires": {
+				"@babel/helper-environment-visitor": "^7.16.7",
+				"@babel/helper-module-imports": "^7.16.7",
+				"@babel/helper-simple-access": "^7.16.7",
+				"@babel/helper-split-export-declaration": "^7.16.7",
+				"@babel/helper-validator-identifier": "^7.16.7",
+				"@babel/template": "^7.16.7",
+				"@babel/traverse": "^7.16.7",
+				"@babel/types": "^7.16.7"
+			}
+		},
+		"@babel/helper-simple-access": {
+			"version": "7.16.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.16.7.tgz",
+			"integrity": "sha512-ZIzHVyoeLMvXMN/vok/a4LWRy8G2v205mNP0XOuf9XRLyX5/u9CnVulUtDgUTama3lT+bf/UqucuZjqiGuTS1g==",
+			"dev": true,
+			"peer": true,
+			"requires": {
+				"@babel/types": "^7.16.7"
+			}
+		},
+		"@babel/helper-split-export-declaration": {
+			"version": "7.16.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.7.tgz",
+			"integrity": "sha512-xbWoy/PFoxSWazIToT9Sif+jJTlrMcndIsaOKvTA6u7QEo7ilkRZpjew18/W3c7nm8fXdUDXh02VXTbZ0pGDNw==",
+			"dev": true,
+			"peer": true,
+			"requires": {
+				"@babel/types": "^7.16.7"
 			}
 		},
 		"@babel/helper-validator-identifier": {
-			"version": "7.15.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
-			"integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
+			"version": "7.16.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
+			"integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
 			"peer": true
 		},
-		"@babel/highlight": {
-			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.0.tgz",
-			"integrity": "sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==",
+		"@babel/helper-validator-option": {
+			"version": "7.16.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.16.7.tgz",
+			"integrity": "sha512-TRtenOuRUVo9oIQGPC5G9DgK4743cdxvtOw0weQNpZXaS16SCBi5MNjZF8vba3ETURjZpTbVn7Vvcf2eAwFozQ==",
+			"dev": true,
+			"peer": true
+		},
+		"@babel/helpers": {
+			"version": "7.17.2",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.17.2.tgz",
+			"integrity": "sha512-0Qu7RLR1dILozr/6M0xgj+DFPmi6Bnulgm9M8BVa9ZCWxDqlSnqt3cf8IDPB5m45sVXUZ0kuQAgUrdSFFH79fQ==",
+			"dev": true,
 			"peer": true,
 			"requires": {
-				"@babel/helper-validator-identifier": "^7.15.7",
+				"@babel/template": "^7.16.7",
+				"@babel/traverse": "^7.17.0",
+				"@babel/types": "^7.17.0"
+			}
+		},
+		"@babel/highlight": {
+			"version": "7.16.10",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.10.tgz",
+			"integrity": "sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==",
+			"peer": true,
+			"requires": {
+				"@babel/helper-validator-identifier": "^7.16.7",
 				"chalk": "^2.0.0",
 				"js-tokens": "^4.0.0"
 			},
@@ -3296,6 +4175,64 @@
 				}
 			}
 		},
+		"@babel/parser": {
+			"version": "7.17.3",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.3.tgz",
+			"integrity": "sha512-7yJPvPV+ESz2IUTPbOL+YkIGyCqOyNIzdguKQuJGnH7bg1WTIifuM21YqokFt/THWh1AkCRn9IgoykTRCBVpzA==",
+			"dev": true,
+			"peer": true
+		},
+		"@babel/template": {
+			"version": "7.16.7",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.7.tgz",
+			"integrity": "sha512-I8j/x8kHUrbYRTUxXrrMbfCa7jxkE7tZre39x3kjr9hvI82cK1FfqLygotcWN5kdPGWcLdWMHpSBavse5tWw3w==",
+			"dev": true,
+			"peer": true,
+			"requires": {
+				"@babel/code-frame": "^7.16.7",
+				"@babel/parser": "^7.16.7",
+				"@babel/types": "^7.16.7"
+			}
+		},
+		"@babel/traverse": {
+			"version": "7.17.3",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.3.tgz",
+			"integrity": "sha512-5irClVky7TxRWIRtxlh2WPUUOLhcPN06AGgaQSB8AEwuyEBgJVuJ5imdHm5zxk8w0QS5T+tDfnDxAlhWjpb7cw==",
+			"dev": true,
+			"peer": true,
+			"requires": {
+				"@babel/code-frame": "^7.16.7",
+				"@babel/generator": "^7.17.3",
+				"@babel/helper-environment-visitor": "^7.16.7",
+				"@babel/helper-function-name": "^7.16.7",
+				"@babel/helper-hoist-variables": "^7.16.7",
+				"@babel/helper-split-export-declaration": "^7.16.7",
+				"@babel/parser": "^7.17.3",
+				"@babel/types": "^7.17.0",
+				"debug": "^4.1.0",
+				"globals": "^11.1.0"
+			},
+			"dependencies": {
+				"globals": {
+					"version": "11.12.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+					"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+					"dev": true,
+					"peer": true
+				}
+			}
+		},
+		"@babel/types": {
+			"version": "7.17.0",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
+			"integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
+			"dev": true,
+			"peer": true,
+			"requires": {
+				"@babel/helper-validator-identifier": "^7.16.7",
+				"to-fast-properties": "^2.0.0"
+			}
+		},
 		"@eslint/eslintrc": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.0.3.tgz",
@@ -3341,6 +4278,31 @@
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz",
 			"integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==",
 			"dev": true
+		},
+		"@jridgewell/resolve-uri": {
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.5.tgz",
+			"integrity": "sha512-VPeQ7+wH0itvQxnG+lIzWgkysKIr3L9sslimFW55rHMdGu/qCQ5z5h9zq4gI8uBtqkpHhsF4Z/OwExufUCThew==",
+			"dev": true,
+			"peer": true
+		},
+		"@jridgewell/sourcemap-codec": {
+			"version": "1.4.11",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.11.tgz",
+			"integrity": "sha512-Fg32GrJo61m+VqYSdRSjRXMjQ06j8YIYfcTqndLYVAaHmroZHLJZCydsWBOTDqXS2v+mjxohBWEMfg97GXmYQg==",
+			"dev": true,
+			"peer": true
+		},
+		"@jridgewell/trace-mapping": {
+			"version": "0.3.4",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.4.tgz",
+			"integrity": "sha512-vFv9ttIedivx0ux3QSjhgtCVjPZd5l46ZOMDSCwnH1yUO2e964gO8LZGyv2QkqcgR6TnBU1v+1IFqmeoG+0UJQ==",
+			"dev": true,
+			"peer": true,
+			"requires": {
+				"@jridgewell/resolve-uri": "^3.0.3",
+				"@jridgewell/sourcemap-codec": "^1.4.10"
+			}
 		},
 		"@nodelib/fs.scandir": {
 			"version": "2.1.5",
@@ -3510,6 +4472,20 @@
 				"fill-range": "^7.0.1"
 			}
 		},
+		"browserslist": {
+			"version": "4.19.3",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.19.3.tgz",
+			"integrity": "sha512-XK3X4xtKJ+Txj8G5c30B4gsm71s69lqXlkYui4s6EkKxuv49qjYlY6oVd+IFJ73d4YymtM3+djvvt/R/iJwwDg==",
+			"dev": true,
+			"peer": true,
+			"requires": {
+				"caniuse-lite": "^1.0.30001312",
+				"electron-to-chromium": "^1.4.71",
+				"escalade": "^3.1.1",
+				"node-releases": "^2.0.2",
+				"picocolors": "^1.0.0"
+			}
+		},
 		"call-bind": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
@@ -3541,6 +4517,13 @@
 				"map-obj": "^4.0.0",
 				"quick-lru": "^4.0.1"
 			}
+		},
+		"caniuse-lite": {
+			"version": "1.0.30001312",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001312.tgz",
+			"integrity": "sha512-Wiz1Psk2MEK0pX3rUzWaunLTZzqS2JYZFzNKqAiJGiuxIjRPLgV6+VDPOg6lQOUxmDwhTlh198JsTTi8Hzw6aQ==",
+			"dev": true,
+			"peer": true
 		},
 		"chalk": {
 			"version": "4.1.2",
@@ -3574,16 +4557,38 @@
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
 		},
+		"colord": {
+			"version": "2.9.2",
+			"resolved": "https://registry.npmjs.org/colord/-/colord-2.9.2.tgz",
+			"integrity": "sha512-Uqbg+J445nc1TKn4FoDPS6ZZqAvEDnwrH42yo8B40JSOgSLxMZ/gt3h4nmCtPLQeXhjJJkqBx7SCY35WnIixaQ==",
+			"peer": true
+		},
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+		},
+		"confusing-browser-globals": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.10.tgz",
+			"integrity": "sha512-gNld/3lySHwuhaVluJUKLePYirM3QNCKzVxqAdhJII9/WXKVX5PURzMVJspS1jTslSqjeuG4KMVTSouit5YPHA==",
+			"dev": true
 		},
 		"console-assert": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/console-assert/-/console-assert-1.0.0.tgz",
 			"integrity": "sha1-cBZwKO8I7BZnoMaHIFqDYOsRc2c=",
 			"dev": true
+		},
+		"convert-source-map": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
+			"integrity": "sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==",
+			"dev": true,
+			"peer": true,
+			"requires": {
+				"safe-buffer": "~5.1.1"
+			}
 		},
 		"cosmiconfig": {
 			"version": "7.0.1",
@@ -3609,6 +4614,17 @@
 				"which": "^2.0.1"
 			}
 		},
+		"css-functions-list": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.0.1.tgz",
+			"integrity": "sha512-PriDuifDt4u4rkDgnqRCLnjfMatufLmWNfQnGCq34xZwpY3oabwhB9SqRBmuvWUgndbemCFlKqg+nO7C2q0SBw==",
+			"peer": true
+		},
+		"css-property-sort-order-smacss": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/css-property-sort-order-smacss/-/css-property-sort-order-smacss-2.2.0.tgz",
+			"integrity": "sha512-nXutswsivIEBOrPo/OZw2KQjFPLvtg68aovJf6Kqrm3L6FmTvvFPaeDrk83hh0+pRJGuP3PeKJwMS0E6DFipdQ=="
+		},
 		"cssesc": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -3616,9 +4632,9 @@
 			"peer": true
 		},
 		"debug": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-			"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+			"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
 			"requires": {
 				"ms": "2.1.2"
 			}
@@ -3679,6 +4695,13 @@
 			"requires": {
 				"esutils": "^2.0.2"
 			}
+		},
+		"electron-to-chromium": {
+			"version": "1.4.71",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.71.tgz",
+			"integrity": "sha512-Hk61vXXKRb2cd3znPE9F+2pLWdIOmP7GjiTj45y6L3W/lO+hSnUSUhq+6lEaERWBdZOHbk2s3YV5c9xVl3boVw==",
+			"dev": true,
+			"peer": true
 		},
 		"emoji-regex": {
 			"version": "8.0.0",
@@ -3742,6 +4765,13 @@
 				"is-date-object": "^1.0.1",
 				"is-symbol": "^1.0.2"
 			}
+		},
+		"escalade": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+			"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+			"dev": true,
+			"peer": true
 		},
 		"escape-string-regexp": {
 			"version": "4.0.0",
@@ -4018,9 +5048,9 @@
 			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
 		},
 		"fast-glob": {
-			"version": "3.2.7",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
-			"integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
+			"version": "3.2.11",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+			"integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
 			"peer": true,
 			"requires": {
 				"@nodelib/fs.stat": "^2.0.2",
@@ -4124,6 +5154,13 @@
 			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
 			"dev": true
 		},
+		"gensync": {
+			"version": "1.0.0-beta.2",
+			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+			"integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+			"dev": true,
+			"peer": true
+		},
 		"get-intrinsic": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
@@ -4214,23 +5251,23 @@
 			}
 		},
 		"globby": {
-			"version": "11.0.4",
-			"resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
-			"integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
+			"version": "11.1.0",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+			"integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
 			"peer": true,
 			"requires": {
 				"array-union": "^2.1.0",
 				"dir-glob": "^3.0.1",
-				"fast-glob": "^3.1.1",
-				"ignore": "^5.1.4",
-				"merge2": "^1.3.0",
+				"fast-glob": "^3.2.9",
+				"ignore": "^5.2.0",
+				"merge2": "^1.4.1",
 				"slash": "^3.0.0"
 			},
 			"dependencies": {
 				"ignore": {
-					"version": "5.1.9",
-					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.9.tgz",
-					"integrity": "sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==",
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+					"integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
 					"peer": true
 				}
 			}
@@ -4264,8 +5301,7 @@
 		"has-flag": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-			"dev": true
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
 		},
 		"has-symbols": {
 			"version": "1.0.2",
@@ -4500,12 +5536,6 @@
 				"has-symbols": "^1.0.2"
 			}
 		},
-		"is-typedarray": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-			"peer": true
-		},
 		"is-weakref": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.1.tgz",
@@ -4543,6 +5573,13 @@
 				}
 			}
 		},
+		"jsesc": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+			"dev": true,
+			"peer": true
+		},
 		"json-parse-even-better-errors": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -4577,9 +5614,9 @@
 			"peer": true
 		},
 		"known-css-properties": {
-			"version": "0.23.0",
-			"resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.23.0.tgz",
-			"integrity": "sha512-h9ivI88e1lFNmTT4HovBN33Ysn0OIJG7IPG2mkpx2uniQXFWqo35QdiX7w0TovlUFXfW8aPFblP5/q0jlOr2sA==",
+			"version": "0.24.0",
+			"resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.24.0.tgz",
+			"integrity": "sha512-RTSoaUAfLvpR357vWzAz/50Q/BmHfmE6ETSWfutT0AJiw10e6CmcdYRQJlLRd95B53D0Y2aD1jSxD3V3ySF+PA==",
 			"peer": true
 		},
 		"levn": {
@@ -4721,16 +5758,22 @@
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 		},
 		"nanoid": {
-			"version": "3.1.30",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.30.tgz",
-			"integrity": "sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ==",
-			"peer": true
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
+			"integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw=="
 		},
 		"natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
 			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
 			"dev": true
+		},
+		"node-releases": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.2.tgz",
+			"integrity": "sha512-XxYDdcQ6eKqp/YjI+tb2C5WM2LgjnZrfYg4vgQt49EK268b6gYCHsBLrK2qvJo4FmCtqmKezb0WZFK4fkrZNsg==",
+			"dev": true,
+			"peer": true
 		},
 		"normalize-package-data": {
 			"version": "3.0.3",
@@ -4888,13 +5931,12 @@
 		"picocolors": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-			"integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-			"peer": true
+			"integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
 		},
 		"picomatch": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-			"integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
 			"peer": true
 		},
 		"pkg-dir": {
@@ -4907,14 +5949,13 @@
 			}
 		},
 		"postcss": {
-			"version": "8.3.11",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.11.tgz",
-			"integrity": "sha512-hCmlUAIlUiav8Xdqw3Io4LcpA1DOt7h3LSTAC4G6JGHFFaWzI6qvFt9oilvl8BmkbBRX1IhM90ZAmpk68zccQA==",
-			"peer": true,
+			"version": "8.4.6",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.6.tgz",
+			"integrity": "sha512-OovjwIzs9Te46vlEx7+uXB0PLijpwjXGKXjVGGPIGubGpq7uh5Xgf6D6FiJ/SzJMBosHDp6a2hiXOS97iBXcaA==",
 			"requires": {
-				"nanoid": "^3.1.30",
+				"nanoid": "^3.2.0",
 				"picocolors": "^1.0.0",
-				"source-map-js": "^0.6.2"
+				"source-map-js": "^1.0.2"
 			}
 		},
 		"postcss-media-query-parser": {
@@ -4937,19 +5978,25 @@
 			"requires": {}
 		},
 		"postcss-selector-parser": {
-			"version": "6.0.6",
-			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.6.tgz",
-			"integrity": "sha512-9LXrvaaX3+mcv5xkg5kFwqSzSH1JIObIx51PrndZwlmznwXRfxMddDvo9gve3gVR8ZTKgoFDdWkbRFmEhT4PMg==",
+			"version": "6.0.9",
+			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.9.tgz",
+			"integrity": "sha512-UO3SgnZOVTwu4kyLR22UQ1xZh086RyNZppb7lLAKBFK8a32ttG5i87Y/P3+2bRSjZNyJ1B7hfFNo273tKe9YxQ==",
 			"peer": true,
 			"requires": {
 				"cssesc": "^3.0.0",
 				"util-deprecate": "^1.0.2"
 			}
 		},
+		"postcss-sorting": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-sorting/-/postcss-sorting-7.0.1.tgz",
+			"integrity": "sha512-iLBFYz6VRYyLJEJsBJ8M3TCqNcckVzz4wFounSc5Oez35ogE/X+aoC5fFu103Ot7NyvjU3/xqIXn93Gp3kJk4g==",
+			"requires": {}
+		},
 		"postcss-value-parser": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
-			"integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+			"integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
 			"peer": true
 		},
 		"prelude-ls": {
@@ -5158,6 +6205,13 @@
 				"queue-microtask": "^1.2.2"
 			}
 		},
+		"safe-buffer": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+			"dev": true,
+			"peer": true
+		},
 		"semver": {
 			"version": "7.3.5",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
@@ -5193,9 +6247,9 @@
 			}
 		},
 		"signal-exit": {
-			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.5.tgz",
-			"integrity": "sha512-KWcOiKeQj6ZyXx7zq4YxSMgHRlod4czeBQZrPb8OKcohcqAXShm7E20kEMle9WBt26hFcAf0qLOcp5zmY7kOqQ==",
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
 			"peer": true
 		},
 		"slash": {
@@ -5215,11 +6269,17 @@
 				"is-fullwidth-code-point": "^3.0.0"
 			}
 		},
-		"source-map-js": {
-			"version": "0.6.2",
-			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-0.6.2.tgz",
-			"integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==",
+		"source-map": {
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+			"dev": true,
 			"peer": true
+		},
+		"source-map-js": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+			"integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw=="
 		},
 		"spdx-correct": {
 			"version": "3.1.1",
@@ -5332,49 +6392,52 @@
 			"peer": true
 		},
 		"stylelint": {
-			"version": "14.0.1",
-			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.0.1.tgz",
-			"integrity": "sha512-ZcAkmFLVCultmwkQUjxKzxW/o5+CzNmDk6TPJj/d4Y7ipTGGrewIWmNm+InjdSr04PR5/yynsAJeYJY/wisdMg==",
+			"version": "14.5.1",
+			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.5.1.tgz",
+			"integrity": "sha512-8Hf4HtnhxlWlf7iXF9zFfhSc3X0teRnVzl6PqPs2JEFx+dy/mhMhghZfiTDW4QG0ihDw9+WP7GZw5Nzx7cQF5A==",
 			"peer": true,
 			"requires": {
 				"balanced-match": "^2.0.0",
+				"colord": "^2.9.2",
 				"cosmiconfig": "^7.0.1",
-				"debug": "^4.3.2",
+				"css-functions-list": "^3.0.1",
+				"debug": "^4.3.3",
 				"execall": "^2.0.0",
-				"fast-glob": "^3.2.7",
+				"fast-glob": "^3.2.11",
 				"fastest-levenshtein": "^1.0.12",
 				"file-entry-cache": "^6.0.1",
 				"get-stdin": "^8.0.0",
 				"global-modules": "^2.0.0",
-				"globby": "^11.0.4",
+				"globby": "^11.1.0",
 				"globjoin": "^0.1.4",
 				"html-tags": "^3.1.0",
-				"ignore": "^5.1.8",
+				"ignore": "^5.2.0",
 				"import-lazy": "^4.0.0",
 				"imurmurhash": "^0.1.4",
 				"is-plain-object": "^5.0.0",
-				"known-css-properties": "^0.23.0",
+				"known-css-properties": "^0.24.0",
 				"mathml-tag-names": "^2.1.3",
 				"meow": "^9.0.0",
 				"micromatch": "^4.0.4",
 				"normalize-path": "^3.0.0",
 				"normalize-selector": "^0.2.0",
 				"picocolors": "^1.0.0",
-				"postcss": "^8.3.11",
+				"postcss": "^8.4.6",
 				"postcss-media-query-parser": "^0.2.3",
 				"postcss-resolve-nested-selector": "^0.1.1",
 				"postcss-safe-parser": "^6.0.0",
-				"postcss-selector-parser": "^6.0.6",
-				"postcss-value-parser": "^4.1.0",
+				"postcss-selector-parser": "^6.0.9",
+				"postcss-value-parser": "^4.2.0",
 				"resolve-from": "^5.0.0",
 				"specificity": "^0.4.1",
 				"string-width": "^4.2.3",
 				"strip-ansi": "^6.0.1",
 				"style-search": "^0.1.0",
+				"supports-hyperlinks": "^2.2.0",
 				"svg-tags": "^1.0.0",
-				"table": "^6.7.2",
+				"table": "^6.8.0",
 				"v8-compile-cache": "^2.3.0",
-				"write-file-atomic": "^3.0.3"
+				"write-file-atomic": "^4.0.1"
 			},
 			"dependencies": {
 				"balanced-match": {
@@ -5384,9 +6447,9 @@
 					"peer": true
 				},
 				"ignore": {
-					"version": "5.1.9",
-					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.9.tgz",
-					"integrity": "sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==",
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+					"integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
 					"peer": true
 				},
 				"resolve-from": {
@@ -5397,19 +6460,46 @@
 				}
 			}
 		},
+		"stylelint-config-property-sort-order-smacss": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/stylelint-config-property-sort-order-smacss/-/stylelint-config-property-sort-order-smacss-9.0.0.tgz",
+			"integrity": "sha512-jQ1miJ6uQA+n6UkunhdhBmjFd5XCe/X7l9/yBI2KGdU+8+nYt1/7slHeLvsT7SCYByYqaLt9fUUCCOjyXH6PCw==",
+			"requires": {
+				"css-property-sort-order-smacss": "~2.2.0",
+				"stylelint-order": "^5.0.0"
+			}
+		},
 		"stylelint-config-recommended": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-6.0.0.tgz",
-			"integrity": "sha512-ZorSSdyMcxWpROYUvLEMm0vSZud2uB7tX1hzBZwvVY9SV/uly4AvvJPPhCcymZL3fcQhEQG5AELmrxWqtmzacw==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-7.0.0.tgz",
+			"integrity": "sha512-yGn84Bf/q41J4luis1AZ95gj0EQwRX8lWmGmBwkwBNSkpGSpl66XcPTulxGa/Z91aPoNGuIGBmFkcM1MejMo9Q==",
 			"requires": {}
+		},
+		"stylelint-order": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/stylelint-order/-/stylelint-order-5.0.0.tgz",
+			"integrity": "sha512-OWQ7pmicXufDw5BlRqzdz3fkGKJPgLyDwD1rFY3AIEfIH/LQY38Vu/85v8/up0I+VPiuGRwbc2Hg3zLAsJaiyw==",
+			"requires": {
+				"postcss": "^8.3.11",
+				"postcss-sorting": "^7.0.1"
+			}
 		},
 		"supports-color": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
 			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-			"dev": true,
 			"requires": {
 				"has-flag": "^4.0.0"
+			}
+		},
+		"supports-hyperlinks": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.2.0.tgz",
+			"integrity": "sha512-6sXEzV5+I5j8Bmq9/vUphGRM/RJNT9SCURJLjwfOg51heRtguGWDzcaBlgAzKhQa0EVNpPEKzQuBwZ8S8WaCeQ==",
+			"peer": true,
+			"requires": {
+				"has-flag": "^4.0.0",
+				"supports-color": "^7.0.0"
 			}
 		},
 		"svg-tags": {
@@ -5419,9 +6509,9 @@
 			"peer": true
 		},
 		"table": {
-			"version": "6.7.3",
-			"resolved": "https://registry.npmjs.org/table/-/table-6.7.3.tgz",
-			"integrity": "sha512-5DkIxeA7XERBqMwJq0aHZOdMadBx4e6eDoFRuyT5VR82J0Ycg2DwM6GfA/EQAhJ+toRTaS1lIdSQCqgrmhPnlw==",
+			"version": "6.8.0",
+			"resolved": "https://registry.npmjs.org/table/-/table-6.8.0.tgz",
+			"integrity": "sha512-s/fitrbVeEyHKFa7mFdkuQMWlH1Wgw/yEXMt5xACT4ZpzWFluehAxRtUUQKPuWhaLAWhFcVx6w3oC8VKaUfPGA==",
 			"peer": true,
 			"requires": {
 				"ajv": "^8.0.1",
@@ -5432,9 +6522,9 @@
 			},
 			"dependencies": {
 				"ajv": {
-					"version": "8.7.1",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.7.1.tgz",
-					"integrity": "sha512-gPpOObTO1QjbnN1sVMjJcp1TF9nggMfO4MBR5uQl6ZVTOaEPq5i4oq/6R9q2alMMPB3eg53wFv1RuJBLuxf3Hw==",
+					"version": "8.10.0",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.10.0.tgz",
+					"integrity": "sha512-bzqAEZOjkrUMl2afH8dknrq5KEk2SrwdBROR+vH1EKVQTqaUbJVPdc/gEdggTMM0Se+s+Ja4ju4TlNcStKl2Hw==",
 					"peer": true,
 					"requires": {
 						"fast-deep-equal": "^3.1.1",
@@ -5456,6 +6546,13 @@
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
 			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
 			"dev": true
+		},
+		"to-fast-properties": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+			"dev": true,
+			"peer": true
 		},
 		"to-regex-range": {
 			"version": "5.0.1",
@@ -5498,15 +6595,6 @@
 			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
 			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
 			"dev": true
-		},
-		"typedarray-to-buffer": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
-			"integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-			"peer": true,
-			"requires": {
-				"is-typedarray": "^1.0.0"
-			}
 		},
 		"unbox-primitive": {
 			"version": "1.0.1",
@@ -5583,15 +6671,13 @@
 			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		},
 		"write-file-atomic": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
-			"integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.1.tgz",
+			"integrity": "sha512-nSKUxgAbyioruk6hU87QzVbY279oYT6uiwgDoujth2ju4mJ+TZau7SQBhtbTmUyuNYTuXnSyRn66FV0+eCgcrQ==",
 			"peer": true,
 			"requires": {
 				"imurmurhash": "^0.1.4",
-				"is-typedarray": "^1.0.0",
-				"signal-exit": "^3.0.2",
-				"typedarray-to-buffer": "^3.1.5"
+				"signal-exit": "^3.0.7"
 			}
 		},
 		"yallist": {

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -20,14 +20,15 @@
 		"url": "https://github.com/acolorbright/acb-tools-and-configs/issues"
 	},
 	"peerDependencies": {
-		"stylelint": "13.x || 14.x"
+		"stylelint": "^14.4.0"
 	},
 	"dependencies": {
-		"@acolorbright/stylelint-config-property-sort-order": "^3.1.0",
-		"stylelint-config-recommended": "6.0.0"
+		"stylelint-config-property-sort-order-smacss": "9.0.0",
+		"stylelint-config-recommended": "7.0.0",
+		"stylelint-order": "5.0.0"
 	},
 	"devDependencies": {
-		"@acolorbright/eslint-config": "^2.1.1",
+		"@acolorbright/eslint-config": "2.1.1",
 		"eslint": "8.0.1",
 		"eslint-plugin-extra-rules": "0.8.1",
 		"eslint-plugin-import": "2.25.2"


### PR DESCRIPTION
**Description**
This PR simplifies the configuration of the property sort order, and also upgrades the other config component of [stylelint-config-recommended](https://github.com/stylelint/stylelint-config-recommended).

**Context**
Previously, we relied on another package, [stylelint-config-property-sort-order](https://github.com/acolorbright/acb-tools-and-configs/tree/main/packages/stylelint-config-property-sort-order), to enforce newlines between the SMACSS property groups. This is now possible to configure directly in our Stylelint configuration (after installing the underlying [stylelint-order](https://github.com/hudochenkov/stylelint-order) dependency directly), which I have done here. This means that we can deprecate the `stylelint-config-property-sort-order` package after this is published.

Since we have now transitioned to Stylelint 14, I also upgraded our `stylelint-config-recommended` dependency to the latest version, which removes support for Stylelint versions below 14.4. 