### PR TITLE
Forbid img elements without width and height attributes

### DIFF
--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -42,6 +42,7 @@
 	"devDependencies": {
 		"@babel/core": "7.15.8",
 		"@babel/eslint-parser": "7.15.8",
+		"@mizdra/eslint-plugin-layout-shift": "1.0.1",
 		"eslint": "8.0.1",
 		"eslint-plugin-extra-rules": "0.8.1",
 		"eslint-plugin-import": "2.25.2"

--- a/packages/eslint-config/rules/extras.js
+++ b/packages/eslint-config/rules/extras.js
@@ -1,6 +1,8 @@
 module.exports = {
-	plugins: ['extra-rules'],
+	plugins: ['extra-rules', '@mizdra/layout-shift'],
 	rules: {
 		'extra-rules/no-commented-out-code': 'error',
+		// Forbid img element without explicit size attributes
+		'@mizdra/layout-shift/require-size-attributes': 'error',
 	},
 };

--- a/packages/eslint-config/rules/extras.js
+++ b/packages/eslint-config/rules/extras.js
@@ -1,6 +1,7 @@
 module.exports = {
 	plugins: ['extra-rules', '@mizdra/layout-shift'],
 	rules: {
+		// Forbid commented out code
 		'extra-rules/no-commented-out-code': 'error',
 		// Forbid img element without explicit size attributes
 		'@mizdra/layout-shift/require-size-attributes': 'error',


### PR DESCRIPTION
Uses https://github.com/mizdra/eslint-plugin-layout-shift to make width and height attributes required for `img` elements. Still not sure if it's possible to test this before publishing, so it might be best to just check the package docs for now.