### PR TITLE
Update browserslist to support last 2 major versions of Safari

### DIFF
--- a/packages/browserslist-config/index.js
+++ b/packages/browserslist-config/index.js
@@ -1,9 +1,9 @@
 module.exports = [
 	"last 2 chrome versions",
 	"last 2 firefox versions",
-	"last 2 safari versions",
+	"last 2 safari major versions",
 	"last 2 edge versions",
-	"last 2 ios_saf versions",
+	"last 2 iOS major versions",
 	"last 2 android versions",
 	"last 2 samsung versions",
 ];


### PR DESCRIPTION
Updates our `browserslist` in order to support a wider range of Safari versions, both on desktop as well as on iOS. Currently we’re only supporting `16.0` and `16.1` at the time of writing, which misses out on `15.6` which has higher usage on both desktop and iOS.

[Before](https://browserslist.dev/?q=bGFzdCAyIGNocm9tZSB2ZXJzaW9ucywgbGFzdCAyIGZpcmVmb3ggdmVyc2lvbnMsIGxhc3QgMiBzYWZhcmkgdmVyc2lvbnMsIGxhc3QgMiBlZGdlIHZlcnNpb25zLCBsYXN0IDIgaW9zX3NhZiB2ZXJzaW9ucywgbGFzdCAyIGFuZHJvaWQgdmVyc2lvbnMsIGxhc3QgMiBzYW1zdW5nIHZlcnNpb25z):

![browserslist-before](https://user-images.githubusercontent.com/1090876/210527660-52461840-b5f8-4385-9a16-712fcb22ead8.png)

[After](https://browserslist.dev/?q=bGFzdCAyIGNocm9tZSB2ZXJzaW9ucywgbGFzdCAyIGZpcmVmb3ggdmVyc2lvbnMsIGxhc3QgMiBzYWZhcmkgbWFqb3IgdmVyc2lvbnMsIGxhc3QgMiBlZGdlIHZlcnNpb25zLCBsYXN0IDIgaU9TIG1ham9yIHZlcnNpb25zLCBsYXN0IDIgYW5kcm9pZCB2ZXJzaW9ucywgbGFzdCAyIHNhbXN1bmcgdmVyc2lvbnM%3D):

![browserslist-after](https://user-images.githubusercontent.com/1090876/210527753-e3be51df-e9bf-454a-b1b2-a24a8d9945d8.png)

