### PR TITLE
Remove `object.assign` package

### DIFF
--- a/packages/eslint-config-react/package-lock.json
+++ b/packages/eslint-config-react/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@acolorbright/eslint-config-react",
-			"version": "3.0.2",
+			"version": "3.0.3",
 			"license": "MIT",
 			"dependencies": {
 				"object.assign": "4.1.2"

--- a/packages/eslint-config-react/rules/react.js
+++ b/packages/eslint-config-react/rules/react.js
@@ -1,4 +1,3 @@
-const assign = require('object.assign');
 const baseStyleRules = require('@acolorbright/eslint-config/rules/style').rules;
 
 const dangleRules = baseStyleRules['no-underscore-dangle'];
@@ -15,7 +14,7 @@ module.exports = {
 	rules: {
 		'no-underscore-dangle': [
 			dangleRules[0],
-			assign({}, dangleRules[1], {
+			Object.assign({}, dangleRules[1], {
 				allow: dangleRules[1].allow.concat([
 					'__REDUX_DEVTOOLS_EXTENSION_COMPOSE__',
 				]),

--- a/packages/eslint-config-ts-react/package-lock.json
+++ b/packages/eslint-config-ts-react/package-lock.json
@@ -6,11 +6,10 @@
 	"packages": {
 		"": {
 			"name": "@acolorbright/eslint-config-ts-react",
-			"version": "3.0.2",
+			"version": "3.0.3",
 			"license": "MIT",
 			"dependencies": {
-				"eslint-config-prettier": "8.3.0",
-				"object.assign": "4.1.2"
+				"eslint-config-prettier": "8.3.0"
 			},
 			"devDependencies": {
 				"@mizdra/eslint-plugin-layout-shift": "1.0.1",
@@ -729,6 +728,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
 			"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+			"dev": true,
 			"dependencies": {
 				"function-bind": "^1.1.1",
 				"get-intrinsic": "^1.0.2"
@@ -843,6 +843,7 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
 			"integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+			"dev": true,
 			"dependencies": {
 				"has-property-descriptors": "^1.0.0",
 				"object-keys": "^1.1.1"
@@ -1682,7 +1683,8 @@
 		"node_modules/function-bind": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+			"dev": true
 		},
 		"node_modules/function.prototype.name": {
 			"version": "1.1.5",
@@ -1720,6 +1722,7 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
 			"integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
+			"dev": true,
 			"dependencies": {
 				"function-bind": "^1.1.1",
 				"has": "^1.0.3",
@@ -1826,6 +1829,7 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
 			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+			"dev": true,
 			"dependencies": {
 				"function-bind": "^1.1.1"
 			},
@@ -1854,6 +1858,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
 			"integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+			"dev": true,
 			"dependencies": {
 				"get-intrinsic": "^1.1.1"
 			},
@@ -1865,6 +1870,7 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
 			"integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+			"dev": true,
 			"engines": {
 				"node": ">= 0.4"
 			},
@@ -2355,6 +2361,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
 			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+			"dev": true,
 			"engines": {
 				"node": ">= 0.4"
 			}
@@ -2363,6 +2370,7 @@
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
 			"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.0",
 				"define-properties": "^1.1.3",
@@ -3554,6 +3562,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
 			"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+			"dev": true,
 			"requires": {
 				"function-bind": "^1.1.1",
 				"get-intrinsic": "^1.0.2"
@@ -3636,6 +3645,7 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
 			"integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+			"dev": true,
 			"requires": {
 				"has-property-descriptors": "^1.0.0",
 				"object-keys": "^1.1.1"
@@ -4279,7 +4289,8 @@
 		"function-bind": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+			"dev": true
 		},
 		"function.prototype.name": {
 			"version": "1.1.5",
@@ -4308,6 +4319,7 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
 			"integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
+			"dev": true,
 			"requires": {
 				"function-bind": "^1.1.1",
 				"has": "^1.0.3",
@@ -4381,6 +4393,7 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
 			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+			"dev": true,
 			"requires": {
 				"function-bind": "^1.1.1"
 			}
@@ -4400,6 +4413,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
 			"integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+			"dev": true,
 			"requires": {
 				"get-intrinsic": "^1.1.1"
 			}
@@ -4407,7 +4421,8 @@
 		"has-symbols": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-			"integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
+			"integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+			"dev": true
 		},
 		"has-tostringtag": {
 			"version": "1.0.0",
@@ -4763,12 +4778,14 @@
 		"object-keys": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+			"dev": true
 		},
 		"object.assign": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
 			"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.0",
 				"define-properties": "^1.1.3",

--- a/packages/eslint-config-ts-react/package.json
+++ b/packages/eslint-config-ts-react/package.json
@@ -28,8 +28,7 @@
 	},
 	"dependencies": {
 		"@acolorbright/eslint-config-ts": "^3.0.3",
-		"eslint-config-prettier": "8.3.0",
-		"object.assign": "4.1.2"
+		"eslint-config-prettier": "8.3.0"
 	},
 	"peerDependencies": {
 		"@typescript-eslint/eslint-plugin": "4.x || 5.x",

--- a/packages/eslint-config-ts-react/rules/react.js
+++ b/packages/eslint-config-ts-react/rules/react.js
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-const assign = require('object.assign')
 const baseStyleRules =
 	require('@acolorbright/eslint-config-ts/rules/style').rules
 
@@ -17,7 +16,7 @@ module.exports = {
 	rules: {
 		'no-underscore-dangle': [
 			dangleRules[0],
-			assign({}, dangleRules[1], {
+			Object.assign({}, dangleRules[1], {
 				allow: dangleRules[1].allow.concat([
 					'__REDUX_DEVTOOLS_EXTENSION_COMPOSE__',
 				]),

--- a/packages/eslint-config/package-lock.json
+++ b/packages/eslint-config/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@acolorbright/eslint-config",
-			"version": "3.0.2",
+			"version": "3.0.3",
 			"license": "MIT",
 			"dependencies": {
 				"confusing-browser-globals": "1.0.11"


### PR DESCRIPTION
Removes the [`object.assign` package](https://www.npmjs.com/package/object-assign) and replace its usage with `Object.assign`:


> Node.js 4 and up, as well as every evergreen browser (Chrome, Edge, Firefox, Opera, Safari), support Object.assign() 🎉. If you target only those environments, then by all means, use Object.assign() instead of this package.