### PR TITLE
fix: use an object spread instead of object.assign

### DIFF
--- a/packages/eslint-config-react/rules/react.js
+++ b/packages/eslint-config-react/rules/react.js
@@ -14,11 +14,12 @@ module.exports = {
 	rules: {
 		'no-underscore-dangle': [
 			dangleRules[0],
-			Object.assign({}, dangleRules[1], {
+			{
+				...dangleRules[1],
 				allow: dangleRules[1].allow.concat([
 					'__REDUX_DEVTOOLS_EXTENSION_COMPOSE__',
 				]),
-			}),
+			},
 		],
 
 		// Specify whether double or single quotes should be used in JSX attributes

--- a/packages/eslint-config-ts-react/rules/react.js
+++ b/packages/eslint-config-ts-react/rules/react.js
@@ -16,11 +16,12 @@ module.exports = {
 	rules: {
 		'no-underscore-dangle': [
 			dangleRules[0],
-			Object.assign({}, dangleRules[1], {
+			{
+				...dangleRules[1],
 				allow: dangleRules[1].allow.concat([
 					'__REDUX_DEVTOOLS_EXTENSION_COMPOSE__',
 				]),
-			}),
+			},
 		],
 
 		// Specify whether double or single quotes should be used in JSX attributes


### PR DESCRIPTION
Fix issue that came up when running `npx lerna run test`:

```
Use an object spread instead of `Object.assign` eg: `{ ...foo }`  prefer-object-spread
```