### PR TITLE
Only .jsx files may have JSX

### DIFF
--- a/packages/eslint-config-react/rules/react.js
+++ b/packages/eslint-config-react/rules/react.js
@@ -342,7 +342,7 @@ module.exports = {
 		'react/jsx-filename-extension': [
 			'warn',
 			{
-				extensions: ['.js', '.jsx'],
+				extensions: ['.jsx'],
 			},
 		],
 


### PR DESCRIPTION
Updates the `react/jsx-filename-extension` rule so that only .jsx files may have JSX