### PR TITLE
Update import rules

### DIFF
--- a/packages/eslint-config-react/index.js
+++ b/packages/eslint-config-react/index.js
@@ -23,5 +23,6 @@ module.exports = {
 		'./rules/react-a11y',
 		'./rules/react-hooks',
 		'./rules/style',
+		'./rules/import',
 	].map(require.resolve),
 };

--- a/packages/eslint-config-react/package-lock.json
+++ b/packages/eslint-config-react/package-lock.json
@@ -18,7 +18,8 @@
 				"eslint-plugin-jsx-a11y": "6.7.1",
 				"eslint-plugin-jsx-control-statements": "3.0.0",
 				"eslint-plugin-react": "7.32.2",
-				"eslint-plugin-react-hooks": "4.6.0"
+				"eslint-plugin-react-hooks": "4.6.0",
+				"eslint-plugin-simple-import-sort": "10.0.0"
 			},
 			"peerDependencies": {
 				"@babel/core": "7.x",
@@ -29,7 +30,8 @@
 				"eslint-plugin-jsx-a11y": "6.x",
 				"eslint-plugin-jsx-control-statements": "2.x || 3.x",
 				"eslint-plugin-react": "7.x",
-				"eslint-plugin-react-hooks": "4.x"
+				"eslint-plugin-react-hooks": "4.x",
+				"eslint-plugin-simple-import-sort": "7.x || 8.x || 9.x || 10.x"
 			}
 		},
 		"node_modules/@ampproject/remapping": {
@@ -1518,6 +1520,15 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/eslint-plugin-simple-import-sort": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-10.0.0.tgz",
+			"integrity": "sha512-AeTvO9UCMSNzIHRkg8S6c3RPy5YEwKWSQPx3DYghLedo2ZQxowPFLGDN1AZ2evfg6r6mjBSZSLxLFsWSu3acsw==",
+			"dev": true,
+			"peerDependencies": {
+				"eslint": ">=5.0.0"
 			}
 		},
 		"node_modules/eslint-scope": {
@@ -4618,6 +4629,13 @@
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
 			"integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
+			"dev": true,
+			"requires": {}
+		},
+		"eslint-plugin-simple-import-sort": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-10.0.0.tgz",
+			"integrity": "sha512-AeTvO9UCMSNzIHRkg8S6c3RPy5YEwKWSQPx3DYghLedo2ZQxowPFLGDN1AZ2evfg6r6mjBSZSLxLFsWSu3acsw==",
 			"dev": true,
 			"requires": {}
 		},

--- a/packages/eslint-config-react/package.json
+++ b/packages/eslint-config-react/package.json
@@ -37,7 +37,8 @@
 		"eslint-plugin-jsx-a11y": "6.x",
 		"eslint-plugin-jsx-control-statements": "2.x || 3.x",
 		"eslint-plugin-react": "7.x",
-		"eslint-plugin-react-hooks": "4.x"
+		"eslint-plugin-react-hooks": "4.x",
+		"eslint-plugin-simple-import-sort": "7.x || 8.x || 9.x || 10.x"
 	},
 	"devDependencies": {
 		"@babel/core": "7.21.3",
@@ -49,6 +50,7 @@
 		"eslint-plugin-jsx-a11y": "6.7.1",
 		"eslint-plugin-jsx-control-statements": "3.0.0",
 		"eslint-plugin-react": "7.32.2",
-		"eslint-plugin-react-hooks": "4.6.0"
+		"eslint-plugin-react-hooks": "4.6.0",
+		"eslint-plugin-simple-import-sort": "10.0.0"
 	}
 }

--- a/packages/eslint-config-react/rules/import.js
+++ b/packages/eslint-config-react/rules/import.js
@@ -1,0 +1,70 @@
+const fs = require('fs');
+
+const src = 'src';
+
+const folders = fs.existsSync(src)
+	? fs
+		.readdirSync(src, { withFileTypes: true })
+		.filter((dirent) => dirent.isDirectory())
+		.map((dirent) => dirent.name)
+	: [];
+
+module.exports = {
+	plugins: ['simple-import-sort'],
+	rules: {
+		'import/no-unresolved': 0,
+		'import/extensions': [
+			'error',
+			'never',
+			{
+				svg: 'always',
+				png: 'always',
+				jpg: 'always',
+				json: 'always',
+				css: 'always',
+				scss: 'always',
+			},
+		],
+		'import/first': 2,
+		'import/newline-after-import': 2,
+		'import/no-duplicates': 2,
+		'import/no-extraneous-dependencies': [
+			'error',
+			{ devDependencies: ['**/*.test.js', '**/*.test.jsx'] },
+		],
+		'import/order': 0,
+		'simple-import-sort/imports': [
+			'error',
+			{
+				groups: [
+					// Side effects
+					['^\\u0000'],
+					// Packages:
+					// 1. `react`-related packages
+					// 2. `next`-related packages
+					// 3. Third-party packages starting with `@` followed by a word character
+					// 4. Third-party packages starting with a word character
+					[
+						'^react',
+						'^@react',
+						'next',
+						`^(@(?!(${folders.join('|')})))\\w+(/.*|$)`,
+						'^\\w',
+					],
+					// Components
+					['^@components(/.*|$)'],
+					// Other absolute `@` imports
+					[`^@(${folders.filter((f) => f !== 'components').join('|')})(/.*|$)`],
+					// Relative imports using `src`
+					['^.*/src/.*'],
+					// Anything not matched in another group.
+					['^'],
+					// Other relative imports
+					['^\\.'],
+				],
+			},
+		],
+		'simple-import-sort/exports': 'error',
+		'sort/imports': 0,
+	},
+};

--- a/packages/eslint-config-ts-react/rules/import.js
+++ b/packages/eslint-config-ts-react/rules/import.js
@@ -22,13 +22,18 @@ module.exports = {
 				png: 'always',
 				jpg: 'always',
 				json: 'always',
+				css: 'always',
 				scss: 'always',
 			},
 		],
+		'import/first': 2,
+		'import/newline-after-import': 2,
+		'import/no-duplicates': 2,
 		'import/no-extraneous-dependencies': [
 			'error',
 			{ devDependencies: ['**/*.test.ts', '**/*.test.tsx'] },
 		],
+		'import/order': 0,
 		'simple-import-sort/imports': [
 			'error',
 			{
@@ -61,5 +66,6 @@ module.exports = {
 			},
 		],
 		'simple-import-sort/exports': 'error',
+		'sort/imports': 0,
 	},
 }


### PR DESCRIPTION
Adds import related rules: see https://github.com/acolorbright/base-next/pull/341

Adds [eslint-plugin-simple-import-sort](https://github.com/lydell/eslint-plugin-simple-import-sort) to `@acolorbright/eslint-config-react`. This is currently added separately in the eslint configuration of our [coding task](https://github.com/acolorbright/coding-task-next/blob/main/.eslintrc.js) and I’d prefer moving that out.