### PR TITLE
Add @mizdra/eslint-plugin-layout-shift as peer dependency

### DIFF
--- a/packages/eslint-config-react/README.md
+++ b/packages/eslint-config-react/README.md
@@ -7,12 +7,14 @@ This plugin provides ACB's `.eslintrc` as an extensible shared config, based on 
 
 The plugin requires `eslint`, `@babel/core`, `@babel/eslint-parser`, and the following other packages:
 
+- `@mizdra/eslint-plugin-layout-shift`
 - `eslint-plugin-extra-rules`
 - `eslint-plugin-import`
 - `eslint-plugin-jsx-a11y`
 - `eslint-plugin-jsx-control-statements`
 - `eslint-plugin-react`
 - `eslint-plugin-react-hooks`
+- `eslint-plugin-simple-import-sort`
 
 If you don't need React, see [eslint-config](https://github.com/acolorbright/acb-tools-and-config/tree/main/packages/eslint-config). For React with TypeScript see [eslint-config-ts-react](https://github.com/acolorbright/acb-tools-and-config/tree/main/packages/eslint-config-ts-react).
 

--- a/packages/eslint-config-react/package.json
+++ b/packages/eslint-config-react/package.json
@@ -31,6 +31,7 @@
 	"peerDependencies": {
 		"@babel/core": "7.x",
 		"@babel/eslint-parser": "7.x",
+		"@mizdra/eslint-plugin-layout-shift": "1.0.1",
 		"eslint": "7.x || 8.x",
 		"eslint-plugin-extra-rules": "^0.8",
 		"eslint-plugin-import": "2.x",

--- a/packages/eslint-config-ts-react/README.md
+++ b/packages/eslint-config-ts-react/README.md
@@ -7,6 +7,7 @@ This plugin provides ACB's `.eslintrc` as an extensible shared config, based on 
 
 The plugin requires `eslint` and the following other packages:
 
+- `@mizdra/eslint-plugin-layout-shift`
 - `@typescript-eslint/eslint-plugin`
 - `@typescript-eslint/parser`
 - `eslint-plugin-extra-rules`
@@ -14,6 +15,7 @@ The plugin requires `eslint` and the following other packages:
 - `eslint-plugin-jsx-a11y`
 - `eslint-plugin-react`
 - `eslint-plugin-react-hooks`
+- `eslint-plugin-simple-import-sort`
 - `typescript`
 
 ```shell

--- a/packages/eslint-config-ts-react/package.json
+++ b/packages/eslint-config-ts-react/package.json
@@ -30,6 +30,7 @@
 		"@acolorbright/eslint-config-ts": "^4.1.1"
 	},
 	"peerDependencies": {
+		"@mizdra/eslint-plugin-layout-shift": "1.0.1",
 		"@typescript-eslint/eslint-plugin": "4.x || 5.x",
 		"@typescript-eslint/parser": "4.x || 5.x",
 		"eslint": "7.x || 8.x",

--- a/packages/eslint-config-ts/README.md
+++ b/packages/eslint-config-ts/README.md
@@ -7,6 +7,7 @@ This plugin provides ACB's base TypeScript `.eslintrc` (without React plugins) a
 
 The plugin requires `eslint`, `typescript` and the following other packages:
 
+- `@mizdra/eslint-plugin-layout-shift`
 - `@typescript-eslint/eslint-plugin`
 - `@typescript-eslint/parser`
 - `eslint-plugin-extra-rules`

--- a/packages/eslint-config-ts/package.json
+++ b/packages/eslint-config-ts/package.json
@@ -30,6 +30,7 @@
 		"@acolorbright/eslint-config": "^3.2.1"
 	},
 	"peerDependencies": {
+		"@mizdra/eslint-plugin-layout-shift": "1.0.1",
 		"@typescript-eslint/eslint-plugin": "4.x || 5.x",
 		"@typescript-eslint/parser": "4.x || 5.x",
 		"eslint": "7.x || 8.x",

--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -7,6 +7,7 @@ This plugin provides ACB's base JS `.eslintrc` (without React plugins) as an ext
 
 The plugin requires `eslint`, `@babel/core`, `@babel/eslint-parser` and the following other packages:
 
+- `@mizdra/eslint-plugin-layout-shift`
 - `eslint-plugin-extra-rules`
 - `eslint-plugin-import`
 


### PR DESCRIPTION
Adds `@mizdra/eslint-plugin-layout-shift` as peer dependency where necessary. It was only listed as a peer dependency in `@acolorbriht/eslint-config`. According to ESLint’s docs:

> If your shareable config depends on a plugin, you should also specify it as a peerDependency

https://eslint.org/docs/latest/extend/shareable-configs#publishing-a-shareable-config

Also updates the README’s where necessary.