### PR TITLE
Update label has associated control options

### DIFF
--- a/packages/eslint-config-react/rules/react-a11y.js
+++ b/packages/eslint-config-react/rules/react-a11y.js
@@ -137,7 +137,7 @@ module.exports = {
 				labelComponents: [],
 				labelAttributes: [],
 				controlComponents: [],
-				assert: 'both',
+				assert: 'either',
 				depth: 25,
 			},
 		],

--- a/packages/eslint-config-react/rules/react-a11y.js
+++ b/packages/eslint-config-react/rules/react-a11y.js
@@ -138,7 +138,7 @@ module.exports = {
 				labelAttributes: [],
 				controlComponents: [],
 				assert: 'either',
-				depth: 25,
+				depth: 2,
 			},
 		],
 

--- a/packages/eslint-config-ts-react/rules/react-a11y.js
+++ b/packages/eslint-config-ts-react/rules/react-a11y.js
@@ -137,7 +137,7 @@ module.exports = {
 				labelComponents: [],
 				labelAttributes: [],
 				controlComponents: [],
-				assert: 'both',
+				assert: 'either',
 				depth: 25,
 			},
 		],

--- a/packages/eslint-config-ts-react/rules/react-a11y.js
+++ b/packages/eslint-config-ts-react/rules/react-a11y.js
@@ -138,7 +138,7 @@ module.exports = {
 				labelAttributes: [],
 				controlComponents: [],
 				assert: 'either',
-				depth: 25,
+				depth: 2,
 			},
 		],
 


### PR DESCRIPTION
## Description

Updates the `jsx-a11y/label-has-associated-control` rule:

- use `either` instead of `both` for `assert`
- stick with the default of `2` for `depth`

## Context

It is a bit weird to require both a `for` attribute and the `label` element wrapping. Also requiring both can result in the following issue:

The label element wraps the input. Axe is satisfied, eslint will throw an error as it wants an `htmlFor` attribute. If this is added Eslint is happy, but can’t or doesn’t check whether the input has an id that is associated with the `htmlFor` JSX attribute. Axe won’t throw an error because it sees the `label` is wrapping the `input`. By require either wrapping or the `htmlFor` attribute Axe will throw an error when the `htmlFor` is present but not associated with an `input.

## Documentation

https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/label-has-associated-control.md#rule-options