### PR TITLE
Expand browser compatibility

### DIFF
--- a/packages/browserslist-config/index.js
+++ b/packages/browserslist-config/index.js
@@ -1,9 +1,13 @@
 module.exports = [
-	"last 2 chrome versions",
-	"last 2 firefox versions",
-	"last 2 safari major versions",
-	"last 2 edge versions",
+	"last 2 Android versions",
+	"last 2 Chrome versions",
+	"last 2 ChromeAndroid versions",
+	"last 2 Edge versions",
+	"last 2 Firefox versions",
+	"last 2 FirefoxAndroid versions",
 	"last 2 iOS major versions",
-	"last 2 android versions",
-	"last 2 samsung versions",
+	"last 2 Opera versions",
+	"last 2 Safari major versions",
+	"last 2 Samsung versions",
+	"not dead"
 ];


### PR DESCRIPTION
Updates our browserslist configuration to expand browser compatibilty.

We currently have an [audience coverage of 31.7%](https://browsersl.ist/#q=last+2+chrome+versions%2Clast+2+firefox+versions%2Clast+2+safari+major+versions%2Clast+2+edge+versions%2Clast+2+iOS+major+versions%2Clast+2+android+versions%2Clast+2+samsung+versions)

This update adds Opera, Chrome for Android, Firefox for Android and adds `not dead` as it gets skipped when using last N versions:

> The not dead query skipped when using last N versions query

It also adds `not OperaMini all` as I think it makes more sense to add this browser per project if necessary.

[Audience coverage after this update becomes 73.7%](https://browsersl.ist/#q=last+2+Android+versions%2Clast+2+Chrome+versions%2Clast+2+ChromeAndroid+versions%2Clast+2+Edge+versions%2Clast+2+Firefox+versions%2Clast+2+FirefoxAndroid+versions%2Clast+2+iOS+major+versions%2Clast+2+Opera+versions%2Clast+2+Safari+major+versions%2Clast+2+Samsung+versions%2Cnot+OperaMini+all%2Cnot+dead).

This seems to be a good baseline, further increasing compatibility makes most sense on a project by project basis by extending this config.