### PR TITLE
Update browserslist configuration

### DIFF
--- a/packages/browserslist-config/index.js
+++ b/packages/browserslist-config/index.js
@@ -1,13 +1,7 @@
 module.exports = [
-	"last 2 Android versions",
-	"last 2 Chrome versions",
-	"last 2 ChromeAndroid versions",
-	"last 2 Edge versions",
-	"last 2 Firefox versions",
-	"last 2 FirefoxAndroid versions",
+	"last 2 versions",
 	"last 2 iOS major versions",
-	"last 2 Opera versions",
 	"last 2 Safari major versions",
-	"last 2 Samsung versions",
+	"not OperaMini all",
 	"not dead"
 ];


### PR DESCRIPTION
Updates our browserslist configuration to simplify things a bit. Instead of explicitly defining each browser we switch to `last 2 versions`. For iOS and Safari we then specify the last 2 major versions: this way we make sure we support version 16 and 15 instead of just 16.4 and 16.3 (at the time of writing).

It also includes `not OperaMini all`: it makes more sense to add this browser per project if necessary, especially regarding how Opera Mini works:

> [Opera Mini](https://en.wikipedia.org/wiki/Opera_Mini) requests web pages through Opera Software's compression proxy server. 

After this update the following browsers are added due to switching to `last 2 versions`:

- UC Browser for Android
- QQ Browser
- KaiOS Browser
- Opera Mobile

Global audience coverage becomes 74.8% (previously 73.7%).

