### PR TITLE
Update dependency stylelint-order

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10733,18 +10733,6 @@
 				"stylelint": "^14.0.0 || ^15.0.0 || ^16.0.0"
 			}
 		},
-		"node_modules/stylelint-config-property-sort-order-smacss/node_modules/stylelint-order": {
-			"version": "6.0.4",
-			"resolved": "https://registry.npmjs.org/stylelint-order/-/stylelint-order-6.0.4.tgz",
-			"integrity": "sha512-0UuKo4+s1hgQ/uAxlYU4h0o0HS4NiQDud0NAUNI0aa8FJdmYHA5ZZTFHiV5FpmE3071e9pZx5j0QpVJW5zOCUA==",
-			"dependencies": {
-				"postcss": "^8.4.32",
-				"postcss-sorting": "^8.0.2"
-			},
-			"peerDependencies": {
-				"stylelint": "^14.0.0 || ^15.0.0 || ^16.0.1"
-			}
-		},
 		"node_modules/stylelint-config-recommended": {
 			"version": "13.0.0",
 			"resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-13.0.0.tgz",
@@ -10757,15 +10745,15 @@
 			}
 		},
 		"node_modules/stylelint-order": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/stylelint-order/-/stylelint-order-6.0.3.tgz",
-			"integrity": "sha512-1j1lOb4EU/6w49qZeT2SQVJXm0Ht+Qnq9GMfUa3pMwoyojIWfuA+JUDmoR97Bht1RLn4ei0xtLGy87M7d29B1w==",
+			"version": "6.0.4",
+			"resolved": "https://registry.npmjs.org/stylelint-order/-/stylelint-order-6.0.4.tgz",
+			"integrity": "sha512-0UuKo4+s1hgQ/uAxlYU4h0o0HS4NiQDud0NAUNI0aa8FJdmYHA5ZZTFHiV5FpmE3071e9pZx5j0QpVJW5zOCUA==",
 			"dependencies": {
-				"postcss": "^8.4.21",
+				"postcss": "^8.4.32",
 				"postcss-sorting": "^8.0.2"
 			},
 			"peerDependencies": {
-				"stylelint": "^14.0.0 || ^15.0.0"
+				"stylelint": "^14.0.0 || ^15.0.0 || ^16.0.1"
 			}
 		},
 		"node_modules/stylelint/node_modules/balanced-match": {
@@ -12300,7 +12288,7 @@
 			"dependencies": {
 				"stylelint-config-property-sort-order-smacss": "10.0.0",
 				"stylelint-config-recommended": "13.0.0",
-				"stylelint-order": "6.0.3"
+				"stylelint-order": "6.0.4"
 			},
 			"devDependencies": {
 				"@acolorbright/eslint-config": "^3.3.0",

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -25,7 +25,7 @@
 	"dependencies": {
 		"stylelint-config-property-sort-order-smacss": "10.0.0",
 		"stylelint-config-recommended": "13.0.0",
-		"stylelint-order": "6.0.3"
+		"stylelint-order": "6.0.4"
 	},
 	"devDependencies": {
 		"@acolorbright/eslint-config": "^3.3.0",


### PR DESCRIPTION
This is a patch update needed for https://github.com/acolorbright/acb-tools-and-configs/pull/142